### PR TITLE
fix(mac): prevent screen lock + Windows feature parity (v3.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ v3 keeps the Windows tray UX exactly as before (download `neveraway.exe`, double
 - `src/NeverAway.Windows` — Windows tray UI (Windows install path) with auto-off scheduler
 - `src/NeverAway.Mac` — macOS menu bar app (Mac install path)
 
-Per-platform key choice:
+Per-platform input simulation:
 
-| platform | key tapped | mechanism |
+| platform | event simulated | mechanism |
 |---|---|---|
-| Windows | F24 (VK 0x87) | `user32.dll keybd_event` |
-| macOS | F19 (key code 80) | `CGEventCreateKeyboardEvent` via P/Invoke |
+| Windows | F24 keystroke (VK 0x87) | `user32.dll keybd_event` |
+| macOS   | zero-pixel mouse-move + IOPM assertions | `CGEventCreateMouseEvent` + `IOPMAssertionCreateWithName` via P/Invoke |
 
-Apple's virtual key code map only defines F1–F20, so F24 has no equivalent on Mac. F19 is the highest-safe F-key — not on any modern keyboard, no default system mapping. F15 is what [Caffeine](https://www.zhornsoftware.co.uk/caffeine/) traditionally used, but on some Mac configurations macOS interprets F15 as "brightness up", so we picked higher.
+Apple's virtual key code map only defines F1–F20, so F24 has no equivalent on Mac. v3.0.0 mac used F19 keystrokes (F15 is what [Caffeine](https://www.zhornsoftware.co.uk/caffeine/) traditionally uses, but on some Mac configurations macOS interprets F15 as "brightness up", so we picked higher). v3.1.0 mac switched to zero-pixel mouse-move + IOPM assertions — synthetic keyboard events alone don't prevent screen lock on modern macOS. see [`docs/macos-lock-investigation.md`](docs/macos-lock-investigation.md) for the rabbit hole.
+
+Mac v3.1.0 also matches the Windows tray's full feature set: two-slot auto-off scheduler, Configure dialog, auto-on re-arm on unlock. defaults match Windows (Slot 1: 2h Duration, Slot 2: 6:00 PM Absolute).
 
 ### Run on macOS — menu bar app (recommended)
 
@@ -43,6 +45,17 @@ Download `NeverAway.app` from the latest release (or build it locally — see be
 Either is one-time. After first successful launch, macOS remembers the decision.
 
 **Accessibility prompt** on first Tap (~10s after launch): "NeverAway wants to control your computer using accessibility features." → Open System Settings → flip the toggle next to NeverAway in the Accessibility list → re-launch NeverAway.
+
+**Menu** (Mac v3.1.0):
+
+- **Pause / Resume** — toggle keep-awake (click ⛔, flips to 🛡 when paused)
+- **Auto-off in 2 hours** (Slot 1, Duration) — click to cycle Off ↔ Once
+- **Auto-off at 6:00 PM** (Slot 2, Absolute) — click to cycle Off → Once → Daily → Off
+- **Configure auto-off...** — opens a dialog to change slot values (minutes for Slot 1, HH:MM for Slot 2)
+- **Cancel scheduled auto-off** — appears when a slot is armed; cancels it
+- **Quit NeverAway**
+
+Auto-on: when the schedule fires (auto-off), unlocking the screen or waking the laptop re-arms NeverAway. Manual-off (clicking Pause) does *not* auto-re-arm — Resume is on you.
 
 Build locally:
 
@@ -61,19 +74,29 @@ dotnet publish src/NeverAway.Windows -c Release
 
 ### Don't want to download? One-liners
 
-If you'd rather not install anything, the same key-tap-in-a-loop fits in a CLI one-liner. Ctrl+C to stop. Same key codes as the binaries (F24 on Windows, F19 on Mac).
+If you'd rather not install anything, here are CLI one-liners that approximate the binaries. Ctrl+C to stop.
 
-**Windows (PowerShell):**
+**Windows (PowerShell)** — same F24-keystroke-in-a-loop as the binary:
 
 ```powershell
 $k=Add-Type -MemberDefinition '[DllImport("user32.dll")]public static extern void keybd_event(byte v,byte s,int f,int e);' -Name N -Namespace W -PassThru;while($true){$k::keybd_event(0x87,0,2,0);Start-Sleep 10}
 ```
 
-**macOS (bash):**
+**macOS (bash)** — `caffeinate` for the IOPM assertions + a swift mouse-move loop for the screensaver-cascade reset (matches what v3.1.0 NeverAway.app does):
+
+```bash
+caffeinate -d -i -u bash -c 'while true; do swift -e "import CoreGraphics; let p = CGEvent(source: nil)!.location; CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: p, mouseButton: .left)?.post(tap: .cghidEventTap)"; sleep 10; done'
+```
+
+ctrl-C in the terminal kills caffeinate, which kills the bash subprocess, which releases all assertions cleanly. first run will prompt for Accessibility permission on `swift`.
+
+if you only need Teams/Slack away suppression (not lock prevention), the simpler v3.0.0 form still works on mac:
 
 ```bash
 while true;do osascript -e 'tell application "System Events" to key code 80';sleep 10;done
 ```
+
+(F19 keystroke. prevents away status + display dim but **does not** prevent screen lock on modern macOS — that's the v3.0.0 bug v3.1.0 fixed.)
 
 ### Tests
 

--- a/dist/mac-app/README.txt
+++ b/dist/mac-app/README.txt
@@ -4,10 +4,10 @@ NeverAway -- macOS menu bar app (Apple Silicon)
 What this does
 --------------
 Sits in your menu bar (top-right of the screen, near the clock /
-wifi / battery widgets) and sends a fake F19 keypress every 10
-seconds so Teams / Slack / similar apps don't show you as "Away".
-F19 isn't on any modern Mac keyboard and has no system mapping,
-so you won't see or feel anything.
+wifi / battery widgets) and posts a zero-pixel mouse-move event
+every 10 seconds so Teams / Slack / similar apps don't show you
+as "Away" and the screen doesn't lock. The cursor doesn't actually
+move (delta is zero), so you won't see or feel anything.
 
 How to run
 ----------
@@ -46,7 +46,7 @@ How to run
        Pause       toggle on/off (icon flips to a shield 🛡 when paused)
        Quit NeverAway
 
-5. The first time NeverAway taps a key (within ~10s of launch),
+5. The first time NeverAway fires a tap (within ~10s of launch),
    macOS will show an Accessibility permission prompt:
 
        "NeverAway wants to control your computer using

--- a/docs/macos-lock-investigation.md
+++ b/docs/macos-lock-investigation.md
@@ -1,0 +1,193 @@
+# macOS screen-lock investigation (v3.0.1)
+
+issue: [neveraway/neveraway#6](https://github.com/neveraway/neveraway/issues/6). PR: [#8](https://github.com/neveraway/neveraway/pull/8).
+
+cold-read context: this is the investigation log for why v3.0.0 mac prevented display darkening but didn't prevent the screen lock, and what we tried. write-up is here so next time anyone (incl. me) hits this kind of macOS idle-counter problem, the diagnostic procedure and the dead ends are recorded — not just the conclusion.
+
+## the bug, in one paragraph
+
+v3.0.0 mac uses a synthetic F19 keystroke via `CGEventCreateKeyboardEvent` + `CGEventPost`, fired every 10s. it correctly prevents display dimming (HIDIdleTime resets) and keeps Teams / Slack from going Away. but after the system's configured screen-lock delay, the screen locks anyway. macOS apparently distinguishes synthetic input (`IOHIDSystem` path, via CGEventPost) from real hardware input (`AppleUserHIDEventService` path, via physical keyboard / mouse / trackpad), and the lock-screen timer is gated on the latter only.
+
+## counters and assertions on macOS, in plain words
+
+modern macOS has at least *four* different "is the user here?" measurements, each driving different behavior:
+
+1. **`HIDIdleTime`** (in `ioreg -c IOHIDSystem`) — nanoseconds since last HID input. resets on both real and synthetic events. drives **display dimming / display sleep**. this is the one HM's diagnostic in the v3 ship arc proved we were resetting.
+2. **`UserIsActive` IOPM assertion** (in `pmset -g assertions`) — declared by `WindowServer` when a HID event fires, or by an app calling `IOPMAssertionDeclareUserActivity`. resets on both real and synthetic events. **600s timeout** if not refreshed. our mouse-jiggle creates these too — `pmset` shows them named `pid:<NeverAway> process:neveraway`.
+3. **`PreventUserIdleDisplaySleep` / `PreventUserIdleSystemSleep` IOPM assertions** — declarative "do not auto-sleep" assertions held by an app for as long as it wants. visible in `pmset -g assertions`. independent of any idle counter; the OS just doesn't auto-sleep while these are held.
+4. **the screen-lock idle counter** — the one driving `sysadminctl -screenLock <delay>`. **this is the counter we can't reach from userspace.** empirically, none of the three above prevent it from firing.
+
+the v3 mental model assumed (1) was the universal counter ("if we reset HIDIdleTime, everything else falls in line"). that's right for display-dim, wrong for screen-lock.
+
+## diagnostic commands (cold-read friendly)
+
+paste any of these into terminal to inspect state. these are the load-bearing ones from this investigation:
+
+### check the lock timer and current settings
+
+```bash
+# the canonical screen-lock delay, in seconds. requires sudo to change.
+sysadminctl -screenLock status
+
+# screen-saver idle time (seconds before saver starts).
+# unset = use system default. set with `defaults -currentHost write`.
+defaults -currentHost read com.apple.screensaver idleTime
+
+# password-required-on-screensaver settings.
+defaults read com.apple.screensaver askForPassword
+defaults read com.apple.screensaver askForPasswordDelay
+```
+
+### check the HID idle counter (HIDIdleTime)
+
+```bash
+ioreg -c IOHIDSystem -r -d 1 -k HIDIdleTime | awk '/HIDIdleTime/ {printf "%.2fs\n", $NF/1e9}'
+```
+
+returns one number in seconds. expectation while NeverAway is active and hands are off: stays ≤10s (it should sawtooth as the 10s tap loop resets it). while paused: grows monotonically.
+
+time-series version that runs for 60s (hands off keyboard / mouse during the run):
+
+```bash
+for i in 1 2 3 4 5 6; do
+  printf "t=%2ds  " $((i*12-12))
+  ioreg -c IOHIDSystem -r -d 1 -k HIDIdleTime | awk '/HIDIdleTime/ {printf "HIDIdle=%.2fs\n", $NF/1e9}'
+  sleep 12
+done
+```
+
+### check IOPM assertions
+
+```bash
+pmset -g assertions
+```
+
+look for entries owned by NeverAway's PID. with the v3.0.1 build (kitchen-sink), you should see *three* assertions named `"NeverAway"`:
+
+- `PreventUserIdleSystemSleep`
+- `PreventUserIdleDisplaySleep`
+- `UserIsActive` (timeout 600s, refreshed each tap)
+
+plus a fourth, owned by `WindowServer` and named `...service:IOHIDSystem pid:<NeverAway> process:neveraway` — that's the assertion WindowServer creates in response to our synthetic mouse-move events.
+
+### check that NeverAway is actually running
+
+```bash
+pgrep -lf 'NeverAway.app/Contents/MacOS/neveraway'
+```
+
+returns PID + path. empty = not running. uptime check:
+
+```bash
+ps -p <PID> -o etime=
+```
+
+## the test cycle, both versions
+
+### normal (slow) test — uses the real screen-lock delay
+
+1. `sysadminctl -screenLock status` — note the delay (default 900s = 15min on roy's machine)
+2. launch NeverAway via `open /path/to/NeverAway.app`
+3. verify with `pmset -g assertions` that all four layers are showing up
+4. step away from the machine for at least `<screenLock delay> + 5 min`
+5. come back; if screen locked, the prevention failed. if still unlocked, it worked.
+
+slow because (4) is real time. used for the canonical validation.
+
+### fast (60-second cycle) test — uses screensaver as a shorter lock path
+
+idea: shrink the cycle by setting the screensaver to start at 60s idle and lock immediately when it does. *if* the screen-lock cascade fires via the screensaver path, this gets us a 1-2 min test cycle instead of 15+ min.
+
+```bash
+defaults -currentHost write com.apple.screensaver idleTime -int 60
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int 0
+```
+
+then:
+
+1. launch NeverAway
+2. verify `pmset -g assertions` shows the four layers
+3. walk away (hands off keyboard / mouse) for ~2 min
+4. observe whether lock fires
+
+restore original settings after testing:
+
+```bash
+defaults -currentHost delete com.apple.screensaver idleTime
+defaults delete com.apple.screensaver askForPassword
+defaults delete com.apple.screensaver askForPasswordDelay
+```
+
+caveat: the screen-saver path is one route into the lock. the canonical `screenLock` timer is a separate route. if the screensaver doesn't trigger the lock on roy's macOS version, this fast-cycle test won't observe the real bug — fall back to the slow version.
+
+## attempts and what they showed (newest first)
+
+### attempt 3: kitchen-sink (current PR head — testing now, 2026-05-13)
+
+`MacInputSimulator` holds:
+
+- `IOPMAssertionCreateWithName(PreventUserIdleDisplaySleep)` — persistent for app lifetime
+- `IOPMAssertionCreateWithName(PreventUserIdleSystemSleep)` — persistent for app lifetime
+- `IOPMAssertionDeclareUserActivity(kIOPMUserActiveLocal)` — refreshed each Tap()
+- the existing zero-pixel `CGEventCreateMouseEvent(kCGEventMouseMoved)` — still fires each Tap()
+
+verified via `pmset -g assertions` that all four assertions show up under NeverAway's pid.
+
+result: **pending empirical validation** as of this writing. testing under the 60s screensaver cycle.
+
+### attempt 2: zero-pixel mouse-jiggle alone (PR draft, before kitchen sink)
+
+idea from apple dev forum #26776 + amphetamine's "automated mouse cursor movement" feature: mouse-move events might trigger different idle counters than keyboard events.
+
+`MacInputSimulator.Tap()` swapped the F19 keystroke for `CGEventCreateMouseEvent(kCGEventMouseMoved, currentPos)` + `CGEventPost(kCGHIDEventTap, ...)`. zero-pixel delta, cursor doesn't visibly move.
+
+result: **the lock still fired.** but the diagnostic data was extremely useful — we confirmed:
+
+- HIDIdleTime sawtooth never exceeded 10s (`0.10, 0.18, 8.38, 0.41, 2.44, 4.47`) → events ARE reaching the HID layer
+- pmset showed `UserIsActive` assertion named `service:IOHIDSystem pid:<NeverAway> process:neveraway` → events ARE creating the UserIsActive assertion via WindowServer
+
+so the failure was NOT "events aren't reaching the OS." failure was "the screen lock counter is independent of HIDIdleTime AND of the WindowServer-mediated UserIsActive."
+
+### attempt 1: original v3.0.0 — F19 keystroke
+
+`CGEventCreateKeyboardEvent(KVK_F19=80)` + `CGEventPost(kCGHIDEventTap, ...)`, every 10s. F19 picked because it has no system mapping on any modern mac keyboard.
+
+result: **prevented display dim + suppressed Teams Away (working as designed for those purposes), but lock still fired** after the configured `screenLock` delay.
+
+post-investigation read: F19 hits the same `IOHIDSystem` path that mouse-jiggle does, so it has the same shape of failure on the lock-screen counter. the mental model in HM's v3 ship arc — "F19 resets HIDIdleTime which suppresses display sleep / system sleep / Teams presence" — was true, but **HIDIdleTime is not the counter the screen-lock uses**. that's the load-bearing correction.
+
+## things we considered and discarded
+
+- **`IOPMAssertionDeclareUserActivity` was originally proposed as the v3.0.1 fix before the mouse-jiggle attempt.** apple dev forum #26776 reports it does not prevent screen saver; our own data shows it gets implicitly invoked (via WindowServer) by any synthetic input event anyway, and it doesn't prevent the lock. we still include the explicit call in the kitchen-sink layer for completeness, but evidence suggests it isn't the missing piece.
+- **caffeinate as a subprocess** — same shape as IOPMAssertion (caffeinate just creates the same assertions we now create directly).
+- **`CGWarpMouseCursorPosition`** — different API that actually moves the cursor pointer rather than posting an event. would still go through the synthetic path; evidence suggests no different result, and would visibly move the cursor.
+- **virtual HID device via `IOHIDUserDevice`** — would make events appear to come from real hardware (the `AppleUserHIDEventService` path). technically the right fix if userspace-CGEvent really can't reach the screen-lock counter. **but** building this requires writing an HID report descriptor, registering a virtual device, dispatching reports — ~200-400 lines of P/Invoke vs our current ~150. it also conflicts with v3's "no Xcode workload, no driver-sign hassle, just net10 + p/invoke" design value. deferred as a v3.0.2 fallback if even the kitchen-sink doesn't fix it.
+
+## what we'll do based on the outcome
+
+**if the kitchen sink works** (lock no longer fires in either the 60s fast-cycle or the 900s slow-cycle test):
+
+- mark PR #8 ready-for-review
+- merge to master
+- tag `v3.0.1`
+- cut release with fresh mac asset + windows v3.0.0 asset byte-reattached
+- this doc stays in the repo as the investigation log
+
+**if the kitchen sink doesn't work** (lock still fires despite all four layers):
+
+- accept that **screen-lock prevention is not achievable from userspace on modern macOS without a virtual HID device**
+- update the dist mac README to clearly state: prevents away-status + display dim, does NOT prevent screen lock (configure your Lock Screen settings if you want the screen to stay unlocked)
+- update PR #8 to reflect the docs-only outcome
+- this doc still gets committed as the investigation log
+- the virtual-HID-device path remains a v3.0.2 option for anyone who wants to chase the last 10%
+
+## one-liner cleanup if you trashed your screensaver settings testing this
+
+```bash
+defaults -currentHost delete com.apple.screensaver idleTime
+defaults delete com.apple.screensaver askForPassword
+defaults delete com.apple.screensaver askForPasswordDelay
+```
+
+restores to system defaults (whatever System Settings > Lock Screen says).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,103 @@
+# NeverAway mac test plan
+
+investigation log lives at [`docs/macos-lock-investigation.md`](macos-lock-investigation.md). this file is the operational test catalogue — what tests exist, what each one validates, and what one-time user intervention is required to run them.
+
+## user prerequisites (one-time intervention)
+
+these grants persist for the same binary signature. rebuilding NeverAway changes the signature hash so the Accessibility grant has to be repeated. on a shipped v3.0.x install (stable signature), all of this is one-time on first run.
+
+1. **Accessibility for NeverAway** — System Settings > Privacy & Security > Accessibility, toggle on for `NeverAway`. without this, `CGEventPost` for the mouse-jiggle layer silently fails (the IOPM assertions still work, but the OS won't see synthetic mouse-move events). triggered automatically by NeverAway's startup prompt if not granted.
+
+2. **Accessibility for System Events** (only if running the test scripts) — same place. when an osascript or test script calls `tell process "neveraway" to click menu item ...`, macOS prompts for this. one-time grant; subsequent osascripts run silently.
+
+3. **screen-lock fast cycle** — `sudo sysadminctl -screenLock 60 -password -` lowers the canonical screen-lock delay to 60 seconds. without this, the slow path tests take 15+ min per iteration. requires admin password. restore with `sudo sysadminctl -screenLock 900 -password -` (default 15 min on most installs).
+
+4. **NSDistributedNotificationCenter post** — no permission needed. any user-space process can post on the default distributed notification center. used by the auto-on synthetic test.
+
+## tests
+
+each test exits 0 on PASS, 1 on FAIL, 2 on NO-DATA (insufficient signal to judge).
+
+### `scripts/test-lock-prevention.sh`
+
+**validates**: kitchen-sink prevents screen lock during natural idle periods.
+
+**method**: applies fast-cycle screensaver settings (60s idle, lock-immediately), runs a watch loop that harvests natural idle windows from the WindowServer UserIsActive assertion age, and reports whether any `Display is turned off` events fired during those windows. restores defaults on exit via trap.
+
+**user intervention**: be naturally idle (away from keyboard / mouse) for at least the `--idle-threshold` (default 90s) at some point during the watch. doesn't have to be deliberate; the script harvests whatever idle windows happen.
+
+**modes**:
+- ACTIVE (NeverAway running) — expect PASS, lock should be prevented
+- CONTROL (NeverAway killed) — expect FAIL, lock should fire
+
+**caveat**: when killing NeverAway for a control run, the lingering WindowServer UserIsActive assertion (named with NeverAway's pid) persists for up to 600s. the test won't see a clean control until that assertion expires. add a 10-12 min wait before control runs, or use `test-isolation.sh` which handles this automatically.
+
+### `scripts/test-isolation.sh`
+
+**validates**: which layer(s) of the kitchen-sink are individually sufficient to prevent the lock.
+
+**method**: runs activity-generator variants sequentially, with a 10-12 min `wait_for_clean_state` between each variant to let the prior variant's WindowServer UserIsActive assertion expire. variants:
+- `control` — nothing running; expect FAIL
+- `caffeinate-u` — UserIsActive only; expect ?
+- `caffeinate-d` — PreventUserIdleDisplaySleep only; expect ?
+- `caffeinate-i` — PreventUserIdleSystemSleep only; expect ?
+- `caffeinate-diu` — all three IOPM together, no mouse-jiggle; expect ?
+- `neveraway` — full kitchen-sink including mouse-jiggle; expect PASS
+
+**user intervention**: walk away for the duration of the test (default 45 min for the 3-variant fast run, longer for the 6-variant full run). real idle is necessary.
+
+**outcome interpretation**:
+- if `caffeinate-diu` PASSes: mouse-jiggle isn't load-bearing, we could simplify NeverAway to just the IOPM assertions
+- if `caffeinate-diu` FAILs but `neveraway` PASSes: mouse-jiggle is the load-bearing layer; kitchen-sink stays as-is
+
+### `scripts/test-auto-off.sh` (NEW)
+
+**validates**: arming a slot causes NeverAway to auto-off itself at the scheduled time.
+
+**method**: clicks `Auto-off in 1 minute` via osascript UI-scripting, watches `pmset -g assertions` until the 3 NeverAway-named entries drop below 3, reports the timing.
+
+**user intervention**: only the first run requires granting System Events Accessibility. subsequent runs are silent.
+
+### `scripts/test-auto-on.sh` (NEW)
+
+**validates**: a screen-unlock event triggers NeverAway to re-arm (assuming it was auto-offed, not manual-paused).
+
+**method**: assumes NeverAway is currently auto-offed (run after `test-auto-off.sh`). posts a synthetic `com.apple.screenIsUnlocked` distributed notification via swift one-liner. watches for NeverAway's IOPM assertions to return.
+
+**user intervention**: none (synthetic notification). a real lock+unlock would also work and is the more authentic test.
+
+### `scripts/test-full-gate.sh` (NEW)
+
+**validates**: the **complete gate sequence** — the "real test" — that the machine actually traverses all the lock-relevant states:
+
+1. arm slot 1 → NeverAway stays active
+2. machine stays awake for the duration of the slot
+3. at slot duration: NeverAway auto-offs
+4. after `sysadminctl -screenLock` delay post-auto-off: display actually turns off + screen locks
+5. on unlock: NeverAway auto-re-arms
+6. IOPM assertions back, machine awake again
+
+each gate is observable from outside the NeverAway process:
+- gate 1: pmset shows 3 NeverAway assertions
+- gate 2: max real-hw-idle in pmset goes high without display-off
+- gate 3: pmset NeverAway assertions drop to 0
+- gate 4: pmset log shows `Display is turned off`
+- gate 5: pmset shows 3 NeverAway assertions return
+- gate 6: pmset log shows `Display is turned on` immediately preceding
+
+**user intervention**: physical lock+unlock (or a synthetic `com.apple.screenIsUnlocked` if testing only the notification-handling). long wait — at least slot-duration + screenLock-delay + small buffer (e.g., 60s slot + 60s lock = 2.5min minimum).
+
+## empirical results so far (2026-05-13)
+
+- **kitchen-sink prevents lock**: PASS over a 2h15min real-world idle observation
+- **lock fires after kill**: PASS (control), display-off at ~12 min after kill, confirmed via `pmset -g log`
+- **slot 1 click-cycle**: PASS, menu state transitions correctly (Off ↔ Once for Duration, Off → Once → Daily → Off for Absolute)
+- **schedule firing**: PASS, slot 1 (1 min Duration) fired at ~60s after arm; IOPM assertions released cleanly
+- **auto-on on real lock+unlock**: PASS, NeverAway re-armed within seconds of unlock
+- **auto-on on synthetic distributed notification**: PASS, same timing
+- **gate 4 (display actually locks post-auto-off)**: ❌ NOT YET VALIDATED. need to run `test-full-gate.sh` to confirm.
+
+## what's known broken
+
+- **Accessibility re-prompt on every rebuild** — unavoidable for ad-hoc-signed bundles, would require Apple Developer ID signing to fix.
+- **Configure dialog Kind switching** — phase 2 fixes Slot 1 as Duration, Slot 2 as Absolute. windows side has radio buttons to switch per slot.

--- a/scripts/test-auto-off.sh
+++ b/scripts/test-auto-off.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Validates that arming slot 1 causes NeverAway to auto-off at the
+# scheduled time.
+#
+# Method:
+#   1. confirm NeverAway is running with all 3 IOPM assertions held
+#   2. arm slot 1 via osascript UI-scripting
+#   3. watch pmset assertions for the count to drop below 3
+#   4. report timing
+#
+# User intervention (one-time, first run only):
+#   - macOS prompts "System Events wants permission to control NeverAway"
+#     when osascript tries to click the menu item. Grant in System Settings
+#     > Privacy & Security > Automation (or Accessibility, depending on
+#     macOS version). Subsequent runs are silent.
+#
+# Exit: 0 = PASS, 1 = FAIL (no auto-off in window), 2 = NO-DATA (precondition failed)
+
+set -euo pipefail
+
+WAIT_MAX_SEC=${WAIT_MAX_SEC:-120}
+
+# 1. precondition: NeverAway running with 3 IOPM assertions
+if ! pgrep -f 'NeverAway.app/Contents/MacOS/neveraway' >/dev/null; then
+  echo "[FAIL] NeverAway not running; launch it before running this test."
+  exit 2
+fi
+count=$(pmset -g assertions | grep -c 'named: "NeverAway"' || true)
+if [ "$count" -lt 3 ]; then
+  echo "[FAIL] NeverAway has only $count of 3 expected IOPM assertions held."
+  echo "       check Accessibility permission for NeverAway, or wait a tap cycle."
+  exit 2
+fi
+echo "[ok] precondition: NeverAway running, 3 IOPM assertions held"
+
+# 2. arm slot 1
+arm_t=$(date +%s)
+osascript -e 'tell application "System Events" to tell process "neveraway" to click menu item "Auto-off in 1 minute" of menu 1 of menu bar item 1 of menu bar 1' >/dev/null
+echo "[arm] $(date '+%H:%M:%S') slot 1 clicked"
+
+# verify the arming took effect
+sleep 1
+items=$(osascript -e 'tell application "System Events" to tell process "neveraway" to get name of every menu item of menu 1 of menu bar item 1 of menu bar 1')
+if [[ "$items" != *"(once)"* ]]; then
+  echo "[FAIL] menu doesn't show (once) after click — arming did not take effect"
+  echo "       menu items: $items"
+  exit 1
+fi
+echo "[ok] menu confirms slot armed: $items"
+
+# 3. wait for auto-off (NeverAway IOPM count drops below 3)
+deadline=$((arm_t + WAIT_MAX_SEC))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  c=$(pmset -g assertions | grep -c 'named: "NeverAway"' || true)
+  if [ "$c" -lt 3 ]; then
+    fire_t=$(date +%s)
+    elapsed=$((fire_t - arm_t))
+    echo "[FIRE] $(date '+%H:%M:%S') auto-off fired after ${elapsed}s (NeverAway IOPM count $c < 3)"
+    echo "[PASS] auto-off cycle works"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[FAIL] auto-off did NOT fire within ${WAIT_MAX_SEC}s of arm"
+exit 1

--- a/scripts/test-auto-on.sh
+++ b/scripts/test-auto-on.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Validates that NeverAway re-arms on a screen-unlock event after
+# having been auto-offed by the schedule.
+#
+# Method:
+#   1. precondition: NeverAway is running but currently auto-offed
+#      (its 3 IOPM assertions are NOT held). The simplest way to
+#      satisfy this is to run test-auto-off.sh first.
+#   2. post a synthetic "com.apple.screenIsUnlocked" notification on
+#      NSDistributedNotificationCenter via swift one-liner
+#   3. watch for NeverAway's IOPM assertions to return (count >= 3)
+#   4. report timing
+#
+# Real-world alternative: physical lock + unlock will post the same
+# notification system-side. This test exists to validate the
+# notification-handling code path without needing the user to lock.
+#
+# User intervention: none (the swift one-liner runs in user-space and
+# posts to the default distributed notification center, which is
+# accessible to any user-space process).
+#
+# Exit: 0 = PASS, 1 = FAIL, 2 = NO-DATA (precondition failed)
+
+set -euo pipefail
+
+WAIT_MAX_SEC=${WAIT_MAX_SEC:-30}
+
+# 1. precondition: NeverAway running but currently auto-offed
+if ! pgrep -f 'NeverAway.app/Contents/MacOS/neveraway' >/dev/null; then
+  echo "[FAIL] NeverAway not running; launch it before running this test."
+  exit 2
+fi
+count=$(pmset -g assertions | grep -c 'named: "NeverAway"' || true)
+if [ "$count" -gt 0 ]; then
+  echo "[FAIL] NeverAway currently has $count IOPM assertions -- expected 0."
+  echo "       run scripts/test-auto-off.sh first to auto-off NeverAway."
+  exit 2
+fi
+echo "[ok] precondition: NeverAway running, currently auto-offed (no IOPM held)"
+
+# 2. post the synthetic unlock notification
+post_t=$(date +%s)
+swift -e 'import Foundation; DistributedNotificationCenter.default().post(name: NSNotification.Name("com.apple.screenIsUnlocked"), object: nil); RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))'
+echo "[post] $(date '+%H:%M:%S') synthetic com.apple.screenIsUnlocked posted"
+
+# 3. wait for IOPM assertions to return
+deadline=$((post_t + WAIT_MAX_SEC))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  c=$(pmset -g assertions | grep -c 'named: "NeverAway"' || true)
+  if [ "$c" -ge 3 ]; then
+    fire_t=$(date +%s)
+    elapsed=$((fire_t - post_t))
+    echo "[FIRE] $(date '+%H:%M:%S') auto-on fired after ${elapsed}s (NeverAway IOPM count $c >= 3)"
+    echo "[PASS] auto-on cycle works"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "[FAIL] auto-on did NOT fire within ${WAIT_MAX_SEC}s of the synthetic notification"
+exit 1

--- a/scripts/test-comprehensive-gates.sh
+++ b/scripts/test-comprehensive-gates.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Comprehensive gate test: sets each macOS idle timer to a distinct
+# short value, then runs three phases:
+#
+#   phase A: NeverAway ON   -- expect ZERO gate events over phase duration
+#   phase B: NeverAway OFF  -- expect each gate to fire at its predicted time
+#   phase C: NeverAway ON   -- expect ZERO again (re-arm validation)
+#
+# Each phase duration is 3 min by default; total ~10 min.
+#
+# Settings applied (distinct timings so each gate is identifiable):
+#   screensaver idleTime    = 30s  -> screensaver starts at T+30s
+#   askForPasswordDelay     =  5s  -> lock (screensaver path)  at T+35s
+#   pmset displaysleep      =  1m  -> display goes off  at T+60s
+#   sysadminctl screenLock  = 15s  -> lock (display path)  at T+75s
+#   pmset sleep             =  2m  -> system sleeps at T+120s
+#
+# Restores original settings on exit via trap.
+#
+# User intervention required:
+#   - sudo password (for pmset + sysadminctl), prompted at start
+#   - account password (for sysadminctl -screenLock), prompted at start
+#   - DO NOT TOUCH keyboard or mouse during phases A and C
+#     (any real input refreshes the idle counters and skews the test)
+#   - phase B kills NeverAway; resumes via menu at end OR test relaunches
+#     it for phase C
+#
+# Exit: 0 = all phases PASS, 1 = any FAIL
+
+set -uo pipefail
+
+PHASE_DURATION_SEC=${PHASE_DURATION_SEC:-180}
+PHASES="${PHASES:-A,B,C}"
+NEVERAWAY_APP="${NEVERAWAY_APP:-/Applications/NeverAway.app}"
+
+# settings being applied during the test
+TEST_SS_IDLE=30
+TEST_SS_PW_DELAY=5
+TEST_DISPLAYSLEEP=1     # minutes (smallest pmset value)
+TEST_SCREENLOCK=15      # seconds
+TEST_SLEEP=2            # minutes
+
+# ----- helpers -----
+
+now_epoch() { date +%s; }
+hms()       { date '+%H:%M:%S'; }
+
+iopm_count() { pmset -g assertions | grep -c 'named: "NeverAway"' || true; }
+
+events_since() {
+  local epoch="$1"
+  local pattern="$2"
+  pmset -g log 2>/dev/null | awk -v since="$epoch" -v pat="$pattern" '
+    $0 ~ pat {
+      ts = $1 " " $2
+      cmd = "date -j -f \"%Y-%m-%d %H:%M:%S\" \"" ts "\" +%s 2>/dev/null"
+      cmd | getline e
+      close(cmd)
+      if (e >= since) c++
+    }
+    END { print c+0 }'
+}
+
+count_display_off()  { events_since "$1" "Display is turned off"; }
+count_display_on()   { events_since "$1" "Display is turned on"; }
+count_sleep_events() { events_since "$1" "Sleep "; }
+count_wake_events()  { events_since "$1" "Wake from"; }
+
+# ----- backup current settings -----
+
+backup_displaysleep=$(pmset -g | awk '/^ displaysleep / {print $2}')
+backup_sleep=$(pmset -g | awk '/^ sleep / {print $2}')
+backup_screenlock=$(sysadminctl -screenLock status 2>&1 | awk '/screenLock delay is/ {print $(NF-1)}')
+backup_ss_idle=$(defaults -currentHost read com.apple.screensaver idleTime 2>/dev/null || echo "unset")
+backup_ss_pw=$(defaults read com.apple.screensaver askForPassword 2>/dev/null || echo "unset")
+backup_ss_pw_delay=$(defaults read com.apple.screensaver askForPasswordDelay 2>/dev/null || echo "unset")
+
+echo "[backup] displaysleep=$backup_displaysleep min"
+echo "[backup] sleep=$backup_sleep min"
+echo "[backup] screenLock=$backup_screenlock s"
+echo "[backup] screensaver idleTime=$backup_ss_idle"
+echo "[backup] askForPassword=$backup_ss_pw"
+echo "[backup] askForPasswordDelay=$backup_ss_pw_delay"
+echo
+
+# ----- prompt for credentials once -----
+
+echo "this test needs admin sudo (for pmset, sysadminctl) and your account password (sysadminctl -screenLock)."
+sudo -v
+echo "enter your account password (for sysadminctl -screenLock, same password as login):"
+read -rs ACCOUNT_PW
+echo
+
+# ----- cleanup trap -----
+
+cleanup() {
+  echo
+  echo "[cleanup] restoring all timers..."
+  sudo pmset -a displaysleep "$backup_displaysleep" >/dev/null 2>&1 || true
+  sudo pmset -a sleep "$backup_sleep" >/dev/null 2>&1 || true
+  echo "$ACCOUNT_PW" | sudo sysadminctl -screenLock "$backup_screenlock" -password - >/dev/null 2>&1 || true
+
+  if [ "$backup_ss_idle" = "unset" ]; then
+    defaults -currentHost delete com.apple.screensaver idleTime 2>/dev/null || true
+  else
+    defaults -currentHost write com.apple.screensaver idleTime -int "$backup_ss_idle"
+  fi
+  if [ "$backup_ss_pw" = "unset" ]; then
+    defaults delete com.apple.screensaver askForPassword 2>/dev/null || true
+  else
+    defaults write com.apple.screensaver askForPassword -int "$backup_ss_pw"
+  fi
+  if [ "$backup_ss_pw_delay" = "unset" ]; then
+    defaults delete com.apple.screensaver askForPasswordDelay 2>/dev/null || true
+  else
+    defaults write com.apple.screensaver askForPasswordDelay -int "$backup_ss_pw_delay"
+  fi
+
+  echo "[cleanup] done."
+}
+trap cleanup EXIT INT TERM
+
+# ----- apply test settings -----
+
+echo "[setup] applying test timers..."
+sudo pmset -a displaysleep "$TEST_DISPLAYSLEEP"
+sudo pmset -a sleep "$TEST_SLEEP"
+echo "$ACCOUNT_PW" | sudo sysadminctl -screenLock "$TEST_SCREENLOCK" -password - >/dev/null 2>&1
+defaults -currentHost write com.apple.screensaver idleTime -int "$TEST_SS_IDLE"
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int "$TEST_SS_PW_DELAY"
+
+echo "[setup] timers applied. expected gate timings (T = start of phase, idle):"
+echo "[setup]   T+${TEST_SS_IDLE}s    screensaver"
+echo "[setup]   T+$((TEST_SS_IDLE + TEST_SS_PW_DELAY))s   lock (screensaver path)"
+echo "[setup]   T+$((TEST_DISPLAYSLEEP * 60))s    display off"
+echo "[setup]   T+$((TEST_DISPLAYSLEEP * 60 + TEST_SCREENLOCK))s    lock (display path)"
+echo "[setup]   T+$((TEST_SLEEP * 60))s   system sleep"
+echo
+
+# ----- phase runner -----
+
+declare -a PHASE_RESULTS
+
+run_phase() {
+  local label="$1"
+  local neveraway_state="$2"  # ON | OFF
+  local expect="$3"           # zero | events
+
+  echo "============================="
+  echo "phase $label: NeverAway $neveraway_state ($PHASE_DURATION_SEC s)"
+  echo "============================="
+
+  # state the precondition
+  if [ "$neveraway_state" = "ON" ]; then
+    if ! pgrep -f 'NeverAway.app/Contents/MacOS/neveraway' >/dev/null; then
+      echo "[setup] NeverAway not running -- launching"
+      open "$NEVERAWAY_APP"
+      sleep 3
+    fi
+    if [ "$(iopm_count)" -lt 3 ]; then
+      echo "[FAIL] NeverAway running but not holding its 3 IOPM assertions"
+      PHASE_RESULTS+=("phase $label FAIL precondition")
+      return
+    fi
+  else
+    if pgrep -f 'NeverAway.app/Contents/MacOS/neveraway' >/dev/null; then
+      echo "[setup] killing NeverAway"
+      pkill -f 'NeverAway.app/Contents/MacOS/neveraway' || true
+      sleep 2
+    fi
+  fi
+
+  # baseline event counts
+  baseline=$(now_epoch)
+  echo "[$(hms)] phase $label start. DO NOT TOUCH keyboard/mouse for $PHASE_DURATION_SEC s."
+
+  # wait the phase duration. periodic status prints every 30s.
+  end=$((baseline + PHASE_DURATION_SEC))
+  while [ "$(now_epoch)" -lt "$end" ]; do
+    sleep 30
+    elapsed=$(( $(now_epoch) - baseline ))
+    do_off=$(count_display_off "$baseline")
+    do_on=$(count_display_on "$baseline")
+    sl=$(count_sleep_events "$baseline")
+    wk=$(count_wake_events "$baseline")
+    echo "  [$(hms)] elapsed=${elapsed}s display-off=$do_off display-on=$do_on sleep=$sl wake=$wk"
+  done
+
+  # final counts
+  do_off=$(count_display_off "$baseline")
+  do_on=$(count_display_on "$baseline")
+  sl=$(count_sleep_events "$baseline")
+  wk=$(count_wake_events "$baseline")
+
+  if [ "$expect" = "zero" ]; then
+    if [ "$do_off" -eq 0 ] && [ "$sl" -eq 0 ]; then
+      verdict=PASS
+    else
+      verdict=FAIL
+    fi
+  else
+    if [ "$do_off" -gt 0 ]; then
+      verdict=PASS
+    else
+      verdict=FAIL
+    fi
+  fi
+
+  echo "[$(hms)] phase $label complete. display-off=$do_off display-on=$do_on sleep=$sl wake=$wk"
+  echo "[$verdict] phase $label expected=$expect, observed display-off=$do_off"
+  PHASE_RESULTS+=("phase $label $verdict (display-off=$do_off sleep=$sl)")
+  echo
+}
+
+# ----- run phases -----
+
+IFS=',' read -ra PHASE_LIST <<< "$PHASES"
+for p in "${PHASE_LIST[@]}"; do
+  case "$p" in
+    A) run_phase A ON  zero ;;
+    B) run_phase B OFF events ;;
+    C) run_phase C ON  zero ;;
+    *) echo "unknown phase: $p" >&2 ;;
+  esac
+done
+
+# ----- summary -----
+
+echo
+echo "============================="
+echo "comprehensive-gates summary"
+echo "============================="
+for r in "${PHASE_RESULTS[@]}"; do
+  echo "  $r"
+done
+
+for r in "${PHASE_RESULTS[@]}"; do
+  case "$r" in *FAIL*) exit 1 ;; esac
+done
+exit 0

--- a/scripts/test-comprehensive-gates.sh
+++ b/scripts/test-comprehensive-gates.sh
@@ -63,8 +63,13 @@ events_since() {
 
 count_display_off()  { events_since "$1" "Display is turned off"; }
 count_display_on()   { events_since "$1" "Display is turned on"; }
-count_sleep_events() { events_since "$1" "Sleep "; }
-count_wake_events()  { events_since "$1" "Wake from"; }
+# system-sleep events look like:
+#   "Entered Sleep" or "Sleep due to ..." -- the standalone column 3 begins with "Sleep"
+# the prior pattern "Sleep " matched tons of unrelated lines (settings logs,
+# timer config descriptions, etc.). this regex requires Sleep as the
+# field-3 *event type* column, not just a substring anywhere.
+count_sleep_events() { events_since "$1" "^[0-9-]+ [0-9:]+ -?[0-9]+[[:space:]]+Sleep[[:space:]]"; }
+count_wake_events()  { events_since "$1" "^[0-9-]+ [0-9:]+ -?[0-9]+[[:space:]]+Wake"; }
 
 # ----- backup current settings -----
 

--- a/scripts/test-full-gate.sh
+++ b/scripts/test-full-gate.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# The "real test": walks every gate in the lock-prevention sequence
+# and reports per-gate PASS/FAIL.
+#
+# Gates:
+#   1. arm slot 1 -- NeverAway stays active
+#   2. machine stays awake for the slot duration (no Display-off event)
+#   3. slot duration reached -- NeverAway auto-offs (3 IOPM released)
+#   4. after sysadminctl -screenLock delay post-auto-off -- display
+#      actually turns off (Display is turned off event in pmset log)
+#   5. unlock event -- NeverAway auto-re-arms (3 IOPM return)
+#   6. machine awake again (no Display-off events for next minute)
+#
+# Method: arm via osascript, observe via pmset assertions + pmset log,
+# trigger the unlock via synthetic distributed notification.
+#
+# User intervention:
+#   - one-time grants per `docs/test-plan.md` (NeverAway Accessibility,
+#     System Events Accessibility, sudo for sysadminctl screenLock)
+#   - DO NOT TOUCH the keyboard or mouse during the test -- real input
+#     events would mask the auto-off-then-lock sequence by refreshing
+#     the WindowServer UserIsActive assertion
+#
+# Total run time: slot_duration + screenLock_delay + ~30s buffer.
+# At slot=60s and screenLock=60s, that's ~2.5min minimum.
+#
+# Exit: 0 = all gates PASS, 1 = any FAIL, 2 = NO-DATA
+
+set -euo pipefail
+
+WAIT_FIRE_MAX_SEC=${WAIT_FIRE_MAX_SEC:-120}    # how long to wait for auto-off
+WAIT_LOCK_MAX_SEC=${WAIT_LOCK_MAX_SEC:-180}    # how long to wait for screen-lock fire
+WAIT_AUTOON_MAX_SEC=${WAIT_AUTOON_MAX_SEC:-30} # how long to wait for auto-on
+
+iopm_count() {
+  pmset -g assertions | grep -c 'named: "NeverAway"' || true
+}
+
+display_off_since() {
+  local epoch="$1"
+  pmset -g log 2>/dev/null | awk -v since="$epoch" '
+    /Display is turned off/ {
+      ts = $1 " " $2
+      cmd = "date -j -f \"%Y-%m-%d %H:%M:%S\" \"" ts "\" +%s 2>/dev/null"
+      cmd | getline e
+      close(cmd)
+      if (e >= since) c++
+    }
+    END { print c+0 }'
+}
+
+declare -a RESULTS
+
+note() { local r="$1" m="$2"; RESULTS+=("$r  $m"); echo "[$r] $m"; }
+
+# preconditions
+if ! pgrep -f 'NeverAway.app/Contents/MacOS/neveraway' >/dev/null; then
+  echo "[FAIL] NeverAway not running"
+  exit 2
+fi
+if [ "$(iopm_count)" -lt 3 ]; then
+  echo "[FAIL] NeverAway not holding its 3 IOPM assertions; ensure Accessibility granted + active state"
+  exit 2
+fi
+lock_delay=$(sysadminctl -screenLock status 2>&1 | awk '/screenLock delay is/ {print $(NF-1)}')
+if [ -z "${lock_delay:-}" ]; then lock_delay=900; fi
+echo "[setup] screenLock delay = ${lock_delay}s"
+echo "[setup] DO NOT TOUCH keyboard/mouse during the test"
+echo
+
+# ---- gate 1: arm slot 1 ----
+arm_t=$(date +%s)
+osascript -e 'tell application "System Events" to tell process "neveraway" to click menu item "Auto-off in 1 minute" of menu 1 of menu bar item 1 of menu bar 1' >/dev/null
+sleep 1
+items=$(osascript -e 'tell application "System Events" to tell process "neveraway" to get name of every menu item of menu 1 of menu bar item 1 of menu bar 1')
+if [[ "$items" == *"(once)"* ]]; then
+  note PASS "gate 1: slot 1 armed (menu shows once)"
+else
+  note FAIL "gate 1: slot arm did not stick (menu: $items)"
+fi
+
+# ---- gates 2+3: wait for auto-off ----
+deadline=$((arm_t + WAIT_FIRE_MAX_SEC))
+fire_t=0
+display_off_before_fire=$(display_off_since "$arm_t")
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  c=$(iopm_count)
+  if [ "$c" -lt 3 ]; then
+    fire_t=$(date +%s)
+    break
+  fi
+  sleep 2
+done
+
+if [ "$fire_t" -eq 0 ]; then
+  note FAIL "gate 3: auto-off did NOT fire within ${WAIT_FIRE_MAX_SEC}s"
+  echo
+  echo "test stopping; can't validate downstream gates without auto-off."
+  exit 1
+fi
+elapsed=$((fire_t - arm_t))
+note PASS "gate 3: auto-off fired after ${elapsed}s (NeverAway IOPM released)"
+
+# Did display turn off DURING the arm window (it shouldn't have)?
+display_off_during_active=$(($(display_off_since "$arm_t") - display_off_before_fire))
+if [ "$display_off_during_active" -eq 0 ]; then
+  note PASS "gate 2: machine stayed awake during the arm window (no Display-off events)"
+else
+  note FAIL "gate 2: $display_off_during_active Display-off event(s) fired DURING the arm window"
+fi
+
+# ---- gate 4: display actually turns off post-auto-off ----
+lock_deadline=$((fire_t + lock_delay + WAIT_LOCK_MAX_SEC - WAIT_FIRE_MAX_SEC))
+lock_t=0
+while [ "$(date +%s)" -lt "$lock_deadline" ]; do
+  c=$(display_off_since "$fire_t")
+  if [ "$c" -ge 1 ]; then
+    lock_t=$(date +%s)
+    break
+  fi
+  sleep 5
+done
+
+if [ "$lock_t" -eq 0 ]; then
+  note FAIL "gate 4: display did NOT turn off within ${lock_delay}s post-auto-off"
+else
+  elapsed_lock=$((lock_t - fire_t))
+  note PASS "gate 4: display turned off ${elapsed_lock}s post-auto-off (matches ~${lock_delay}s screenLock delay)"
+fi
+
+# ---- gate 5: trigger unlock + auto-on ----
+post_t=$(date +%s)
+swift -e 'import Foundation; DistributedNotificationCenter.default().post(name: NSNotification.Name("com.apple.screenIsUnlocked"), object: nil); RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))' 2>/dev/null
+deadline=$((post_t + WAIT_AUTOON_MAX_SEC))
+autoon_t=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  c=$(iopm_count)
+  if [ "$c" -ge 3 ]; then
+    autoon_t=$(date +%s)
+    break
+  fi
+  sleep 1
+done
+
+if [ "$autoon_t" -eq 0 ]; then
+  note FAIL "gate 5: auto-on did NOT fire after synthetic unlock notification"
+else
+  elapsed_on=$((autoon_t - post_t))
+  note PASS "gate 5: auto-on fired ${elapsed_on}s after synthetic unlock (NeverAway IOPM back)"
+fi
+
+# ---- gate 6: machine stays awake after auto-on (brief check) ----
+sleep 20
+display_off_after_autoon=$(display_off_since "$autoon_t")
+if [ "$display_off_after_autoon" -eq 0 ]; then
+  note PASS "gate 6: machine stayed awake post-auto-on (no Display-off in 20s window)"
+else
+  note FAIL "gate 6: $display_off_after_autoon Display-off events post-auto-on"
+fi
+
+# ---- summary ----
+echo
+echo "============================="
+echo "full-gate test summary"
+echo "============================="
+for r in "${RESULTS[@]}"; do
+  echo "  $r"
+done
+
+# Any FAIL → exit 1
+for r in "${RESULTS[@]}"; do
+  case "$r" in FAIL*) exit 1 ;; esac
+done
+exit 0

--- a/scripts/test-isolation.sh
+++ b/scripts/test-isolation.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Isolation test for macOS screen-lock prevention mechanisms.
+#
+# Runs through several activity-generator variants sequentially, each
+# under the same fast-cycle screensaver settings, and reports which
+# variants prevented the lock from firing.
+#
+# Activity generators tested:
+#   control            -- nothing; lock SHOULD fire
+#   caffeinate-u       -- caffeinate -u  (UserIsActive only)
+#   caffeinate-d       -- caffeinate -d  (PreventUserIdleDisplaySleep only)
+#   caffeinate-i       -- caffeinate -i  (PreventUserIdleSystemSleep only)
+#   caffeinate-diu     -- caffeinate -d -i -u  (all three IOPM assertions, no mouse-jiggle)
+#   neveraway          -- NeverAway.app (kitchen sink: 3 IOPM + mouse-jiggle)
+#
+# Each variant runs for VARIANT_DURATION_MIN minutes. Real-hardware idle
+# is harvested from the WindowServer UserIsActive assertion age in
+# `pmset -g assertions`. Display-off events are counted in `pmset -g log`.
+#
+# IMPORTANT: between variants the script waits for the *previous*
+# variant's UserIsActive assertion to time out (up to 600s) before
+# starting the next variant. Otherwise the lingering assertion would
+# contaminate the new variant -- WindowServer-owned UserIsActive
+# assertions cannot be force-released, only timed-out. With 3 variants
+# the test budget is roughly 3 * (10min wait + 5min test) = 45min.
+#
+# Verdict per variant:
+#   PASS     -- real idle >= threshold AND zero display-off events
+#   FAIL     -- display-off event fired during variant window
+#   NO-DATA  -- never observed real-hw-idle >= threshold (test inconclusive)
+#
+# Usage:
+#   ./test-isolation.sh                                    # run defaults
+#   ./test-isolation.sh --variants control,caffeinate-u    # subset
+#   ./test-isolation.sh --variant-minutes 5                # custom per-variant time
+#
+# This is the test that answers "which layer is the load-bearing one?".
+
+set -euo pipefail
+
+VARIANT_DURATION_MIN=5
+IDLE_THRESHOLD_SEC=90
+SCREENSAVER_IDLE_SEC=60
+SAMPLE_INTERVAL_SEC=10
+INTER_VARIANT_WAIT_MAX_SEC=720  # 12 min cap on assertion-expiry wait
+VARIANTS_DEFAULT="control caffeinate-diu neveraway"
+VARIANTS="$VARIANTS_DEFAULT"
+NEVERAWAY_APP="/Users/roy/gh/neveraway/publish/mac-app/NeverAway.app"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --variant-minutes)   VARIANT_DURATION_MIN="$2"; shift 2 ;;
+    --idle-threshold)    IDLE_THRESHOLD_SEC="$2"; shift 2 ;;
+    --screensaver-idle)  SCREENSAVER_IDLE_SEC="$2"; shift 2 ;;
+    --sample-interval)   SAMPLE_INTERVAL_SEC="$2"; shift 2 ;;
+    --variants)          VARIANTS=$(echo "$2" | tr ',' ' '); shift 2 ;;
+    --neveraway-app)     NEVERAWAY_APP="$2"; shift 2 ;;
+    --wait-max)          INTER_VARIANT_WAIT_MAX_SEC="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+real_hw_idle_seconds() {
+  pmset -g assertions 2>/dev/null | awk '
+    /WindowServer.*UserIsActive/ && /product:/ {
+      split($4, t, ":")
+      print t[1]*3600 + t[2]*60 + t[3]
+      found=1
+      exit
+    }
+    END { if (!found) print 9999 }'
+}
+
+display_off_count_since() {
+  local since="$1"
+  pmset -g log 2>/dev/null |
+    awk -v since="$since" '
+      /Display is turned off/ {
+        ts = $1 " " $2
+        cmd = "date -j -f \"%Y-%m-%d %H:%M:%S\" \"" ts "\" +%s 2>/dev/null"
+        cmd | getline epoch
+        close(cmd)
+        if (epoch >= since) count++
+      }
+      END { print count+0 }'
+}
+
+stop_all_generators() {
+  pkill -f 'NeverAway.app/Contents/MacOS/neveraway' 2>/dev/null || true
+  pkill -x caffeinate 2>/dev/null || true
+  sleep 1
+}
+
+# How many seconds until the most-recent contamination expires?
+# Looks at any WindowServer UserIsActive whose name mentions caffeinate
+# or "process:neveraway" -- these are residue from prior variants.
+# Returns the max remaining-timeout in seconds, or 0 if none found.
+contamination_remaining_seconds() {
+  pmset -g assertions 2>/dev/null | awk '
+    BEGIN { max=0; cur_is_residue=0 }
+    /WindowServer.*UserIsActive/ {
+      cur_is_residue = ($0 ~ /(caffeinate|process:neveraway)/) ? 1 : 0
+      next
+    }
+    cur_is_residue && /Timeout will fire in/ {
+      for (i=1; i<=NF; i++) {
+        if ($i == "in" && $(i+1) ~ /^[0-9]+$/) {
+          if ($(i+1) > max) max = $(i+1)
+        }
+      }
+      cur_is_residue = 0
+    }
+    END { print max }'
+}
+
+wait_for_clean_state() {
+  local cap="$1"
+  local waited=0
+  while [ "$waited" -lt "$cap" ]; do
+    local remaining
+    remaining=$(contamination_remaining_seconds)
+    if [ "$remaining" -le 1 ]; then
+      echo "  [clean] state is clean (no residual UserIsActive from prior variants)"
+      return 0
+    fi
+    if [ "$((remaining + waited))" -gt "$cap" ]; then
+      echo "  [clean] residual assertion has ${remaining}s remaining but exceeds wait cap (${cap}s) -- proceeding anyway, results may be contaminated"
+      return 0
+    fi
+    echo "  [clean] residual UserIsActive assertion has ${remaining}s remaining; waiting..."
+    sleep $(( remaining > 60 ? 60 : remaining ))
+    waited=$(( waited + (remaining > 60 ? 60 : remaining) ))
+  done
+}
+
+start_generator() {
+  local variant="$1"
+  case "$variant" in
+    control)        ;;  # nothing
+    caffeinate-u)   caffeinate -u -t 86400 &  ;;
+    caffeinate-d)   caffeinate -d -t 86400 &  ;;
+    caffeinate-i)   caffeinate -i -t 86400 &  ;;
+    caffeinate-diu) caffeinate -d -i -u -t 86400 &  ;;
+    neveraway)
+      if [ ! -d "$NEVERAWAY_APP" ]; then
+        echo "[error] NeverAway.app not found at $NEVERAWAY_APP" >&2
+        return 1
+      fi
+      open "$NEVERAWAY_APP"
+      sleep 2  # let it come up and create assertions
+      ;;
+    *) echo "[error] unknown variant: $variant" >&2; return 1 ;;
+  esac
+}
+
+apply_fast_cycle() {
+  defaults -currentHost write com.apple.screensaver idleTime -int "$SCREENSAVER_IDLE_SEC"
+  defaults write com.apple.screensaver askForPassword -int 1
+  defaults write com.apple.screensaver askForPasswordDelay -int 0
+}
+
+restore_defaults() {
+  defaults -currentHost delete com.apple.screensaver idleTime 2>/dev/null || true
+  defaults delete com.apple.screensaver askForPassword 2>/dev/null || true
+  defaults delete com.apple.screensaver askForPasswordDelay 2>/dev/null || true
+}
+
+cleanup() {
+  echo
+  echo "[cleanup] stopping all generators..."
+  stop_all_generators
+  echo "[cleanup] restoring screensaver defaults..."
+  restore_defaults
+  echo "[cleanup] done."
+}
+trap cleanup EXIT INT TERM
+
+# --- setup ---
+
+apply_fast_cycle
+stop_all_generators
+
+echo "[setup] screensaver idle = ${SCREENSAVER_IDLE_SEC}s, lock-immediately"
+echo "[setup] variants to run: $VARIANTS"
+echo "[setup] each variant runs for $VARIANT_DURATION_MIN min; real-hw-idle threshold $IDLE_THRESHOLD_SEC s"
+echo "[setup] estimated total time: $(( $(echo "$VARIANTS" | wc -w | tr -d ' ') * VARIANT_DURATION_MIN )) min"
+echo
+
+# --- per-variant loop ---
+
+declare -a RESULTS_VARIANT
+declare -a RESULTS_VERDICT
+declare -a RESULTS_IDLE
+declare -a RESULTS_OFFS
+
+for variant in $VARIANTS; do
+  echo "============================================="
+  echo "variant: $variant"
+  echo "============================================="
+
+  stop_all_generators
+  wait_for_clean_state "$INTER_VARIANT_WAIT_MAX_SEC"
+  start_generator "$variant" || { echo "[skip] $variant"; continue; }
+
+  variant_start=$(date +%s)
+  variant_end=$((variant_start + VARIANT_DURATION_MIN * 60))
+  max_idle=0
+
+  while [ "$(date +%s)" -lt "$variant_end" ]; do
+    now=$(date +%s)
+    idle=$(real_hw_idle_seconds)
+    if [ "$idle" -gt "$max_idle" ]; then max_idle=$idle; fi
+    offs=$(display_off_count_since "$variant_start")
+    elapsed=$((now - variant_start))
+    printf "  [%s] elapsed=%ds idle=%ds max-idle=%ds display-offs=%d\n" \
+      "$(date '+%H:%M:%S')" "$elapsed" "$idle" "$max_idle" "$offs"
+
+    # short-circuit on FAIL: if a display-off fired, we have our answer
+    if [ "$offs" -gt 0 ]; then
+      echo "  early FAIL — display-off fired, ending variant early"
+      break
+    fi
+    sleep "$SAMPLE_INTERVAL_SEC"
+  done
+
+  final_offs=$(display_off_count_since "$variant_start")
+  if [ "$final_offs" -gt 0 ]; then
+    verdict=FAIL
+  elif [ "$max_idle" -ge "$IDLE_THRESHOLD_SEC" ]; then
+    verdict=PASS
+  else
+    verdict=NO-DATA
+  fi
+
+  RESULTS_VARIANT+=("$variant")
+  RESULTS_VERDICT+=("$verdict")
+  RESULTS_IDLE+=("$max_idle")
+  RESULTS_OFFS+=("$final_offs")
+
+  echo "  result: $verdict (max-idle=${max_idle}s, display-offs=$final_offs)"
+  echo
+done
+
+# --- results table ---
+
+echo
+echo "==============================="
+echo "isolation test summary"
+echo "==============================="
+printf "%-18s %-9s %-10s %-12s\n" "variant" "verdict" "max-idle" "display-offs"
+printf "%-18s %-9s %-10s %-12s\n" "------------------" "---------" "----------" "------------"
+for i in "${!RESULTS_VARIANT[@]}"; do
+  printf "%-18s %-9s %-10s %-12s\n" \
+    "${RESULTS_VARIANT[$i]}" \
+    "${RESULTS_VERDICT[$i]}" \
+    "${RESULTS_IDLE[$i]}s" \
+    "${RESULTS_OFFS[$i]}"
+done
+echo
+echo "guide:"
+echo "  PASS     = real-hw-idle >= ${IDLE_THRESHOLD_SEC}s AND zero display-off events => this variant prevented the lock"
+echo "  FAIL     = display-off event fired during the variant => this variant did NOT prevent the lock"
+echo "  NO-DATA  = real-hw-idle never reached threshold => test inconclusive for this variant"

--- a/scripts/test-lock-prevention.sh
+++ b/scripts/test-lock-prevention.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Programmatic test for macOS screen-lock prevention.
+#
+# Harvests natural idle periods (no need to deliberately step away).
+# Configures short screensaver settings, watches for any "Display is
+# turned off" event in `pmset -g log`, and at the end reports:
+#   - how many display-off events fired during the watch
+#   - the longest "real hardware idle" window observed (gap between
+#     real-keyboard/mouse events in pmset log)
+#
+# The longest real-hardware-idle is what tells us whether the test had
+# real signal: if Roy never went idle, the test is NO-DATA.
+#
+# Critical: "HIDIdleTime" is the WRONG signal for active-mode tests --
+# NeverAway resets it every tap, so it can't grow past ~10s. The
+# real-hardware-idle is the gap between WindowServer's "Created
+# UserIsActive" entries that mention a hardware product (e.g.
+# AppleHIDKeyboardEventDriver, AppleMultitouchDevice). Those entries
+# fire only on physical input.
+#
+# Usage:
+#   ./test-lock-prevention.sh                          # default 30min watch
+#   ./test-lock-prevention.sh --max-watch-minutes 60   # custom cap
+#   ./test-lock-prevention.sh --idle-threshold 90      # min real idle for valid signal (seconds)
+#   ./test-lock-prevention.sh --screensaver-idle 60    # screensaver idle to apply
+
+set -euo pipefail
+
+MAX_WATCH_MINUTES=30
+IDLE_THRESHOLD_SEC=90
+SCREENSAVER_IDLE_SEC=60
+SAMPLE_INTERVAL_SEC=10
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --max-watch-minutes) MAX_WATCH_MINUTES="$2"; shift 2 ;;
+    --idle-threshold)    IDLE_THRESHOLD_SEC="$2"; shift 2 ;;
+    --screensaver-idle)  SCREENSAVER_IDLE_SEC="$2"; shift 2 ;;
+    --sample-interval)   SAMPLE_INTERVAL_SEC="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# seconds since last real-hardware HID input.
+#
+# Reads the age (HH:MM:SS field) of the current WindowServer UserIsActive
+# assertion that's named with a "product:" tag -- those are tied to real
+# hardware (AppleHIDKeyboardEventDriver, AppleMultitouchDevice, USB Receiver,
+# etc.). Our synthetic CGEvents create WindowServer UserIsActive too but
+# they're named with "pid:<NeverAway> process:neveraway" instead, no
+# "product:" -- so the filter cleanly isolates real input.
+#
+# If no such line exists in `pmset -g assertions`, the assertion has expired
+# (>600s since last real input) -- we return 9999 as a sentinel for "very
+# idle".
+real_hw_idle_seconds() {
+  pmset -g assertions 2>/dev/null | awk '
+    /WindowServer.*UserIsActive/ && /product:/ {
+      split($4, t, ":")
+      print t[1]*3600 + t[2]*60 + t[3]
+      found=1
+      exit
+    }
+    END { if (!found) print 9999 }'
+}
+
+# count of "Display is turned off" entries in pmset log since given epoch.
+display_off_count_since() {
+  local since="$1"
+  pmset -g log 2>/dev/null |
+    awk -v since="$since" '
+      /Display is turned off/ {
+        ts = $1 " " $2
+        cmd = "date -j -f \"%Y-%m-%d %H:%M:%S\" \"" ts "\" +%s 2>/dev/null"
+        cmd | getline epoch
+        close(cmd)
+        if (epoch >= since) count++
+      }
+      END { print count+0 }'
+}
+
+cleanup() {
+  echo
+  echo "[cleanup] restoring screensaver defaults..."
+  defaults -currentHost delete com.apple.screensaver idleTime 2>/dev/null || true
+  defaults delete com.apple.screensaver askForPassword 2>/dev/null || true
+  defaults delete com.apple.screensaver askForPasswordDelay 2>/dev/null || true
+  echo "[cleanup] done."
+}
+trap cleanup EXIT INT TERM
+
+# --- setup ---
+
+echo "[setup] applying fast-cycle screensaver settings..."
+defaults -currentHost write com.apple.screensaver idleTime -int "$SCREENSAVER_IDLE_SEC"
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int 0
+
+NEVERAWAY_PID=$(pgrep -f 'NeverAway.app/Contents/MacOS/neveraway' || true)
+if [ -n "$NEVERAWAY_PID" ]; then
+  ASSERTION_COUNT=$(pmset -g assertions | grep -c 'named: "NeverAway"' || true)
+  MODE="ACTIVE (NeverAway PID $NEVERAWAY_PID, $ASSERTION_COUNT IOPM assertions held)"
+else
+  MODE="CONTROL (NeverAway NOT running -- lock SHOULD fire after idle)"
+fi
+
+echo "[setup] mode: $MODE"
+echo "[setup] screensaver idle = ${SCREENSAVER_IDLE_SEC}s, lock-immediately"
+echo "[setup] watching for ${MAX_WATCH_MINUTES} min; min real-hw-idle for valid signal: ${IDLE_THRESHOLD_SEC}s"
+echo
+
+# --- watch loop ---
+
+start_epoch=$(date +%s)
+end_epoch=$((start_epoch + MAX_WATCH_MINUTES * 60))
+max_real_hw_idle=0
+
+while [ "$(date +%s)" -lt "$end_epoch" ]; do
+  now=$(date +%s)
+  real_idle=$(real_hw_idle_seconds)
+  if [ "$real_idle" -gt "$max_real_hw_idle" ]; then
+    max_real_hw_idle=$real_idle
+  fi
+  display_offs=$(display_off_count_since "$start_epoch")
+  elapsed=$((now - start_epoch))
+  printf "[%s] elapsed=%ds real-hw-idle=%ds max-idle-seen=%ds display-offs=%d\n" \
+    "$(date '+%H:%M:%S')" "$elapsed" "$real_idle" "$max_real_hw_idle" "$display_offs"
+  sleep "$SAMPLE_INTERVAL_SEC"
+done
+
+# --- verdict ---
+
+final_display_offs=$(display_off_count_since "$start_epoch")
+
+echo
+echo "==== verdict ===="
+echo "mode: $MODE"
+echo "watch duration: ${MAX_WATCH_MINUTES} min"
+echo "max real-hardware idle observed: ${max_real_hw_idle}s"
+echo "display-off events during watch: $final_display_offs"
+echo
+
+if [ "$max_real_hw_idle" -lt "$IDLE_THRESHOLD_SEC" ]; then
+  echo "result: NO-DATA -- you stayed active (max idle ${max_real_hw_idle}s < threshold ${IDLE_THRESHOLD_SEC}s)"
+  echo "        bump --max-watch-minutes or step away at least once during the watch"
+  exit 2
+elif [ "$final_display_offs" -gt 0 ]; then
+  echo "result: FAIL -- screen lock fired ${final_display_offs} time(s) during watch"
+  exit 1
+else
+  echo "result: PASS -- ${max_real_hw_idle}s of real-hardware idle observed, zero display-off events"
+  exit 0
+fi

--- a/src/NeverAway.Mac/MacInputSimulator.cs
+++ b/src/NeverAway.Mac/MacInputSimulator.cs
@@ -92,6 +92,9 @@ public sealed class MacInputSimulator : IInputSimulator
     [DllImport(IOKit)]
     private static extern int IOPMAssertionDeclareUserActivity(IntPtr name, int userType, ref uint assertionId);
 
+    [DllImport(IOKit)]
+    private static extern int IOPMAssertionRelease(uint assertionId);
+
     // --- Persistent state for the IOPM assertions ---
 
     private static IntPtr _appName;
@@ -106,16 +109,43 @@ public sealed class MacInputSimulator : IInputSimulator
     {
         if (_persistentReady) return;
 
-        _appName = CFStringCreateWithCString(IntPtr.Zero, "NeverAway", CFStringEncodingUTF8);
-        _displaySleepType = CFStringCreateWithCString(IntPtr.Zero, "PreventUserIdleDisplaySleep", CFStringEncodingUTF8);
-        _systemSleepType = CFStringCreateWithCString(IntPtr.Zero, "PreventUserIdleSystemSleep", CFStringEncodingUTF8);
+        if (_appName == IntPtr.Zero)
+            _appName = CFStringCreateWithCString(IntPtr.Zero, "NeverAway", CFStringEncodingUTF8);
+        if (_displaySleepType == IntPtr.Zero)
+            _displaySleepType = CFStringCreateWithCString(IntPtr.Zero, "PreventUserIdleDisplaySleep", CFStringEncodingUTF8);
+        if (_systemSleepType == IntPtr.Zero)
+            _systemSleepType = CFStringCreateWithCString(IntPtr.Zero, "PreventUserIdleSystemSleep", CFStringEncodingUTF8);
 
-        // Held for app lifetime. Visible in `pmset -g assertions`. Non-fatal
-        // if either fails -- the mouse-jiggle layer below still functions.
+        // Held while NeverAway is active. Released by Pause() so paused state
+        // lets the machine behave normally (display sleep, screen lock fire).
+        // Re-created on Resume by the next Tap().
         IOPMAssertionCreateWithName(_displaySleepType, IOPMAssertionLevelOn, _appName, out _displaySleepAssertion);
         IOPMAssertionCreateWithName(_systemSleepType, IOPMAssertionLevelOn, _appName, out _systemSleepAssertion);
 
         _persistentReady = true;
+    }
+
+    // Release all held assertions. Called when NeverAway is paused so the
+    // OS resumes normal idle behavior (display sleep, screen lock can fire
+    // again). Next Tap() will re-create them via EnsurePersistentAssertions().
+    public void ReleaseAllAssertions()
+    {
+        if (_displaySleepAssertion != 0)
+        {
+            IOPMAssertionRelease(_displaySleepAssertion);
+            _displaySleepAssertion = 0;
+        }
+        if (_systemSleepAssertion != 0)
+        {
+            IOPMAssertionRelease(_systemSleepAssertion);
+            _systemSleepAssertion = 0;
+        }
+        if (_userActiveAssertion != 0)
+        {
+            IOPMAssertionRelease(_userActiveAssertion);
+            _userActiveAssertion = 0;
+        }
+        _persistentReady = false;
     }
 
     public void Tap()

--- a/src/NeverAway.Mac/MacInputSimulator.cs
+++ b/src/NeverAway.Mac/MacInputSimulator.cs
@@ -3,33 +3,57 @@ using NeverAway.Core;
 
 namespace NeverAway.Mac;
 
-// CGEvent-based F19 keypress via raw P/Invoke into ApplicationServices.
-// F19 (kVK_F19 = 80) is the highest-safe macOS virtual key code -- not
-// on any physical keyboard, no system mapping. Same key the Console
-// runner uses, but posted via CGEvent directly instead of shelling
-// out to osascript.
+// CGEvent-based zero-pixel mouse-move via raw P/Invoke into
+// ApplicationServices.
 //
-// Why this approach:
-//   - Single permission category: Accessibility (vs osascript's
-//     Automation prompt). One unified prompt for the .app bundle.
-//   - No process spawn per tick (~30ms savings, irrelevant at 10s
-//     intervals but still cleaner).
-//   - No Xcode / macos workload needed -- raw P/Invoke into a system
-//     framework is plain net10.0.
+// v3.0.0 used a synthetic F19 keypress via CGEventCreateKeyboardEvent +
+// CGEventPost. On modern macOS, synthetic keyboard events reset the HID
+// idle counter (so display dim / sleep is correctly prevented) but do
+// NOT reset the screen-saver idle counter. Screen saver activation
+// gates the lock screen via "Require password after screen saver begins
+// or display is turned off" in System Settings, so the lock fires even
+// while we're "tapping" the keyboard. Power-assertion APIs
+// (IOPMAssertionDeclareUserActivity, IOPMAssertionCreateWithName) have
+// the same limitation -- they prevent display sleep but not screen
+// saver. The known-working approach is a synthetic mouse-move event,
+// same shape Amphetamine's "automated mouse cursor movement" feature
+// uses to fill the gap.
 //
-// First call triggers the macOS Accessibility permission prompt:
-//   "NeverAway wants to control your computer using accessibility..."
-// User clicks through to System Settings > Privacy & Security >
-// Accessibility, toggles NeverAway on. Subsequent runs work without
-// further prompts.
+// We probe the current cursor position via CGEventCreate + CGEventGetLocation,
+// then post a mouse-moved event at the same coordinates. Zero-pixel
+// delta -- the cursor doesn't actually move, but the screen-saver idle
+// counter resets.
+//
+// Permission requirement is unchanged: Accessibility. CGEventPost gates
+// the same way for keyboard and mouse events.
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct CGPoint
+{
+    public double X;
+    public double Y;
+}
+
 public sealed class MacInputSimulator : IInputSimulator
 {
-    private const ushort KVK_F19 = 80;
     private const string ApplicationServices =
         "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices";
 
+    // CGEventType.kCGEventMouseMoved = 5
+    private const uint CGEventMouseMoved = 5;
+    // CGMouseButton.kCGMouseButtonLeft = 0 (ignored for mouse-moved, required by signature)
+    private const uint CGMouseButtonLeft = 0;
+    // CGEventTapLocation.HID = 0 (lowest in the chain, all observers see it)
+    private const uint TapLocationHid = 0;
+
     [DllImport(ApplicationServices)]
-    private static extern IntPtr CGEventCreateKeyboardEvent(IntPtr source, ushort virtualKey, [MarshalAs(UnmanagedType.I1)] bool keyDown);
+    private static extern IntPtr CGEventCreate(IntPtr source);
+
+    [DllImport(ApplicationServices)]
+    private static extern CGPoint CGEventGetLocation(IntPtr ev);
+
+    [DllImport(ApplicationServices)]
+    private static extern IntPtr CGEventCreateMouseEvent(IntPtr source, uint mouseType, CGPoint position, uint button);
 
     [DllImport(ApplicationServices)]
     private static extern void CGEventPost(uint tap, IntPtr ev);
@@ -37,23 +61,18 @@ public sealed class MacInputSimulator : IInputSimulator
     [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
     private static extern void CFRelease(IntPtr cf);
 
-    // CGEventTapLocation.HID = 0 (lowest in the chain, all observers see it)
-    private const uint TapLocationHid = 0;
-
     public void Tap()
     {
-        var down = CGEventCreateKeyboardEvent(IntPtr.Zero, KVK_F19, true);
-        if (down != IntPtr.Zero)
-        {
-            CGEventPost(TapLocationHid, down);
-            CFRelease(down);
-        }
+        var probe = CGEventCreate(IntPtr.Zero);
+        if (probe == IntPtr.Zero) return;
+        var pos = CGEventGetLocation(probe);
+        CFRelease(probe);
 
-        var up = CGEventCreateKeyboardEvent(IntPtr.Zero, KVK_F19, false);
-        if (up != IntPtr.Zero)
+        var ev = CGEventCreateMouseEvent(IntPtr.Zero, CGEventMouseMoved, pos, CGMouseButtonLeft);
+        if (ev != IntPtr.Zero)
         {
-            CGEventPost(TapLocationHid, up);
-            CFRelease(up);
+            CGEventPost(TapLocationHid, ev);
+            CFRelease(ev);
         }
     }
 }

--- a/src/NeverAway.Mac/MacInputSimulator.cs
+++ b/src/NeverAway.Mac/MacInputSimulator.cs
@@ -3,29 +3,36 @@ using NeverAway.Core;
 
 namespace NeverAway.Mac;
 
-// CGEvent-based zero-pixel mouse-move via raw P/Invoke into
-// ApplicationServices.
+// Belt-and-suspenders user-activity simulation on macOS.
 //
-// v3.0.0 used a synthetic F19 keypress via CGEventCreateKeyboardEvent +
-// CGEventPost. On modern macOS, synthetic keyboard events reset the HID
-// idle counter (so display dim / sleep is correctly prevented) but do
-// NOT reset the screen-saver idle counter. Screen saver activation
-// gates the lock screen via "Require password after screen saver begins
-// or display is turned off" in System Settings, so the lock fires even
-// while we're "tapping" the keyboard. Power-assertion APIs
-// (IOPMAssertionDeclareUserActivity, IOPMAssertionCreateWithName) have
-// the same limitation -- they prevent display sleep but not screen
-// saver. The known-working approach is a synthetic mouse-move event,
-// same shape Amphetamine's "automated mouse cursor movement" feature
-// uses to fill the gap.
+// Three layers, each addressing a different idle counter:
 //
-// We probe the current cursor position via CGEventCreate + CGEventGetLocation,
-// then post a mouse-moved event at the same coordinates. Zero-pixel
-// delta -- the cursor doesn't actually move, but the screen-saver idle
-// counter resets.
+//   1. Persistent IOPM assertions (created once at first Tap()):
+//        - PreventUserIdleDisplaySleep -- declares display-sleep is off
+//        - PreventUserIdleSystemSleep  -- declares system-sleep is off
+//      These are held continuously while the app runs. Visible in
+//      `pmset -g assertions`.
 //
-// Permission requirement is unchanged: Accessibility. CGEventPost gates
-// the same way for keyboard and mouse events.
+//   2. IOPMAssertionDeclareUserActivity refreshed each Tap()
+//      (kIOPMUserActiveLocal). Documented to "reset the system idle
+//      timer." Apple Developer Forums thread #26776 reports this does
+//      NOT prevent screen-saver activation; we include it anyway as a
+//      cheap layer in case the per-system behavior differs.
+//
+//   3. Zero-pixel CGEventCreateMouseEvent at the current cursor
+//      position (the v3.0.1 mouse-jiggle). Empirically confirmed to
+//      reset HIDIdleTime in a sawtooth pattern and to trigger
+//      WindowServer-mediated UserIsActive assertions (visible in
+//      `pmset -g assertions` named with pid:<NeverAway>). This is what
+//      keeps Teams/Slack from going Away and what suppressed display
+//      dimming in v3.0.0 (with F19) and v3.0.1-pre (with mouse-jiggle).
+//
+// Empirical finding from diagnostics 2026-05-12: layer 3 alone is not
+// sufficient to prevent screen lock on modern macOS. The lock timer
+// appears to track real-hardware events via AppleUserHIDEventService
+// separately from synthetic events via IOHIDSystem. Layers 1+2 may
+// fill that gap; if not, screen-lock prevention is genuinely
+// unavailable from userspace on modern macOS and we'll document.
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct CGPoint
@@ -38,13 +45,24 @@ public sealed class MacInputSimulator : IInputSimulator
 {
     private const string ApplicationServices =
         "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices";
+    private const string CoreFoundation =
+        "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+    private const string IOKit =
+        "/System/Library/Frameworks/IOKit.framework/IOKit";
 
-    // CGEventType.kCGEventMouseMoved = 5
+    // CGEvent constants
     private const uint CGEventMouseMoved = 5;
-    // CGMouseButton.kCGMouseButtonLeft = 0 (ignored for mouse-moved, required by signature)
     private const uint CGMouseButtonLeft = 0;
-    // CGEventTapLocation.HID = 0 (lowest in the chain, all observers see it)
     private const uint TapLocationHid = 0;
+
+    // CFString encoding for assertion names / types
+    private const uint CFStringEncodingUTF8 = 0x08000100;
+
+    // IOPM constants
+    private const uint IOPMAssertionLevelOn = 255;
+    private const int IOPMUserActiveLocal = 0;
+
+    // --- CGEvent P/Invokes (mouse-jiggle layer) ---
 
     [DllImport(ApplicationServices)]
     private static extern IntPtr CGEventCreate(IntPtr source);
@@ -58,11 +76,58 @@ public sealed class MacInputSimulator : IInputSimulator
     [DllImport(ApplicationServices)]
     private static extern void CGEventPost(uint tap, IntPtr ev);
 
-    [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
+    // --- CFString P/Invoke (assertion name/type strings) ---
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFStringCreateWithCString(IntPtr alloc, string str, uint encoding);
+
+    [DllImport(CoreFoundation)]
     private static extern void CFRelease(IntPtr cf);
+
+    // --- IOPM P/Invokes (assertion layer) ---
+
+    [DllImport(IOKit)]
+    private static extern int IOPMAssertionCreateWithName(IntPtr assertionType, uint level, IntPtr name, out uint assertionId);
+
+    [DllImport(IOKit)]
+    private static extern int IOPMAssertionDeclareUserActivity(IntPtr name, int userType, ref uint assertionId);
+
+    // --- Persistent state for the IOPM assertions ---
+
+    private static IntPtr _appName;
+    private static IntPtr _displaySleepType;
+    private static IntPtr _systemSleepType;
+    private static uint _displaySleepAssertion;
+    private static uint _systemSleepAssertion;
+    private static uint _userActiveAssertion;
+    private static bool _persistentReady;
+
+    private static void EnsurePersistentAssertions()
+    {
+        if (_persistentReady) return;
+
+        _appName = CFStringCreateWithCString(IntPtr.Zero, "NeverAway", CFStringEncodingUTF8);
+        _displaySleepType = CFStringCreateWithCString(IntPtr.Zero, "PreventUserIdleDisplaySleep", CFStringEncodingUTF8);
+        _systemSleepType = CFStringCreateWithCString(IntPtr.Zero, "PreventUserIdleSystemSleep", CFStringEncodingUTF8);
+
+        // Held for app lifetime. Visible in `pmset -g assertions`. Non-fatal
+        // if either fails -- the mouse-jiggle layer below still functions.
+        IOPMAssertionCreateWithName(_displaySleepType, IOPMAssertionLevelOn, _appName, out _displaySleepAssertion);
+        IOPMAssertionCreateWithName(_systemSleepType, IOPMAssertionLevelOn, _appName, out _systemSleepAssertion);
+
+        _persistentReady = true;
+    }
 
     public void Tap()
     {
+        EnsurePersistentAssertions();
+
+        // Layer 2: refresh "user activity" declaration. assertionId is
+        // refreshed in-place (0 first time = create new; subsequent calls
+        // refresh the same assertion).
+        IOPMAssertionDeclareUserActivity(_appName, IOPMUserActiveLocal, ref _userActiveAssertion);
+
+        // Layer 3: zero-pixel mouse-move at current cursor position.
         var probe = CGEventCreate(IntPtr.Zero);
         if (probe == IntPtr.Zero) return;
         var pos = CGEventGetLocation(probe);

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -60,6 +60,7 @@ internal static class Program
     private static volatile bool _isActive = true;
     private static IntPtr _toggleItem;
     private static IntPtr _statusButton;
+    private static MacInputSimulator? _sim;
 
     // Match the Windows tray's deliberate icon choice:
     //   active   = SystemIcons.Error (red alert)        -> "no entry" ⛔
@@ -75,6 +76,11 @@ internal static class Program
             Msg(_toggleItem, Sel("setTitle:"), NSString(_isActive ? "Pause" : "Resume"));
         if (_statusButton != IntPtr.Zero)
             Msg(_statusButton, Sel("setTitle:"), NSString(_isActive ? IconActive : IconInactive));
+        // On Pause, release IOPM assertions so the OS resumes normal idle
+        // behavior (display sleep, screen lock can fire). On Resume, the
+        // next Tap() re-creates them via EnsurePersistentAssertions().
+        if (!_isActive)
+            _sim?.ReleaseAllAssertions();
     }
 
     [UnmanagedCallersOnly]
@@ -167,7 +173,10 @@ internal static class Program
         Msg(statusItem, Sel("setMenu:"), menu);
 
         // Tap loop on threadpool. CGEvent posting is thread-safe.
-        var sim = new MacInputSimulator();
+        // Stored in static _sim so the toggle handler can call
+        // ReleaseAllAssertions() when paused.
+        _sim = new MacInputSimulator();
+        var sim = _sim;
         _ = Task.Run(async () =>
         {
             while (true)

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -40,6 +40,20 @@ internal static class Program
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr MsgB(IntPtr o, IntPtr s, byte b);
     // performSelectorOnMainThread:withObject:waitUntilDone: -- last arg is BOOL (byte).
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern void MsgPerformOnMain(IntPtr o, IntPtr s, IntPtr a, IntPtr b, byte c);
+    // initWithFrame: / setFrame: -- takes a CGRect by value.
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr MsgRect(IntPtr o, IntPtr s, CGRect r);
+    // runModal -- returns NSInteger (long).
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern long MsgRetL(IntPtr o, IntPtr s);
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CGSize { public double Width; public double Height; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CGRect
+    {
+        public double X, Y, Width, Height;
+        public CGRect(double x, double y, double w, double h) { X = x; Y = y; Width = w; Height = h; }
+    }
 
     // Accessibility check + auto-prompt. Documented in <ApplicationServices/AXUIElement.h>.
     // Pass a CFDictionary with kAXTrustedCheckOptionPrompt=YES to fire the system prompt
@@ -156,6 +170,96 @@ internal static class Program
         RefreshScheduleMenu();
     }
 
+    // Configure dialog: NSAlert with accessoryView containing two labeled
+    // text fields, one per slot. Slot 1 (Duration): minutes value. Slot 2
+    // (Absolute): HH:MM time-of-day. Kind is fixed per slot to match the
+    // Windows defaults; phase 3 could add Kind switching.
+    [UnmanagedCallersOnly]
+    private static void OnConfigurePressed(IntPtr self, IntPtr cmd)
+    {
+        var alert = Msg(Msg(Cls("NSAlert"), Sel("alloc")), Sel("init"));
+        Msg(alert, Sel("setMessageText:"), NSString("Configure auto-off"));
+        Msg(alert, Sel("setInformativeText:"),
+            NSString("Slot 1: total minutes to count down (Duration).\nSlot 2: time of day to fire at, HH:MM 24-hr (Absolute)."));
+        Msg(alert, Sel("addButtonWithTitle:"), NSString("Save"));
+        Msg(alert, Sel("addButtonWithTitle:"), NSString("Cancel"));
+
+        // Accessory view: 320x80 with two label+field pairs stacked vertically
+        var accessory = MsgRect(Msg(Cls("NSView"), Sel("alloc")), Sel("initWithFrame:"),
+            new CGRect(0, 0, 320, 80));
+
+        IntPtr slot1Label = CreateLabel("Slot 1 (minutes):", new CGRect(0, 50, 130, 22));
+        IntPtr slot1Field = CreateTextField(
+            ((int)_schedule.Slot1.Value.TotalMinutes).ToString(CultureInfo.InvariantCulture),
+            new CGRect(140, 50, 80, 22));
+
+        IntPtr slot2Label = CreateLabel("Slot 2 (HH:MM):", new CGRect(0, 10, 130, 22));
+        IntPtr slot2Field = CreateTextField(
+            $"{_schedule.Slot2.Value.Hours:D2}:{_schedule.Slot2.Value.Minutes:D2}",
+            new CGRect(140, 10, 80, 22));
+
+        Msg(accessory, Sel("addSubview:"), slot1Label);
+        Msg(accessory, Sel("addSubview:"), slot1Field);
+        Msg(accessory, Sel("addSubview:"), slot2Label);
+        Msg(accessory, Sel("addSubview:"), slot2Field);
+
+        Msg(alert, Sel("setAccessoryView:"), accessory);
+
+        long response = MsgRetL(alert, Sel("runModal"));
+        // NSAlertFirstButtonReturn = 1000 (Save), NSAlertSecondButtonReturn = 1001 (Cancel)
+        if (response != 1000) return;
+
+        var slot1Text = GetTextFieldString(slot1Field);
+        var slot2Text = GetTextFieldString(slot2Field);
+
+        if (int.TryParse(slot1Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int min1) && min1 > 0)
+            _schedule.Slot1.Value = TimeSpan.FromMinutes(min1);
+
+        if (TimeSpan.TryParseExact(slot2Text, @"h\:mm", CultureInfo.InvariantCulture, out TimeSpan tod1)
+            || TimeSpan.TryParseExact(slot2Text, @"hh\:mm", CultureInfo.InvariantCulture, out tod1))
+        {
+            // Normalize to a 0-23:59 time-of-day. anything outside that range
+            // is invalid -- silently ignore (user can re-open).
+            if (tod1 >= TimeSpan.Zero && tod1 < TimeSpan.FromDays(1))
+                _schedule.Slot2.Value = tod1;
+        }
+
+        _schedule.Recompute(DateTime.Now);
+        RefreshScheduleMenu();
+    }
+
+    // Helpers for the Configure accessory view.
+
+    private static IntPtr CreateLabel(string text, CGRect frame)
+    {
+        var tf = MsgRect(Msg(Cls("NSTextField"), Sel("alloc")), Sel("initWithFrame:"), frame);
+        Msg(tf, Sel("setStringValue:"), NSString(text));
+        // Configure as a read-only label: not editable, not selectable, no
+        // bezel, no draws-background. mirrors [NSTextField labelWithString:]
+        // on macOS 10.12+ but with explicit calls (no convenience class
+        // method needed via P/Invoke).
+        MsgB(tf, Sel("setEditable:"), 0);
+        MsgB(tf, Sel("setSelectable:"), 0);
+        MsgB(tf, Sel("setBezeled:"), 0);
+        MsgB(tf, Sel("setDrawsBackground:"), 0);
+        return tf;
+    }
+
+    private static IntPtr CreateTextField(string initialValue, CGRect frame)
+    {
+        var tf = MsgRect(Msg(Cls("NSTextField"), Sel("alloc")), Sel("initWithFrame:"), frame);
+        Msg(tf, Sel("setStringValue:"), NSString(initialValue));
+        return tf;
+    }
+
+    private static string GetTextFieldString(IntPtr tf)
+    {
+        var nsstr = Msg(tf, Sel("stringValue"));
+        if (nsstr == IntPtr.Zero) return string.Empty;
+        var utf8Ptr = Msg(nsstr, Sel("UTF8String"));
+        return Marshal.PtrToStringUTF8(utf8Ptr) ?? string.Empty;
+    }
+
     // NSWorkspace session-unlock + power-resume both route here. Re-arm
     // NeverAway iff the last off was auto (not manual).
     [UnmanagedCallersOnly]
@@ -211,7 +315,7 @@ internal static class Program
         // The Objective-C runtime needs a real class with selectors --
         // can't dispatch [target action:] to a raw function pointer.
         var actionClass = objc_allocateClassPair(Cls("NSObject"), "NeverAwayActionTarget", 0);
-        IntPtr togglePtr, quitPtr, slot1Ptr, slot2Ptr, cancelPtr, autoOffPtr, wakePtr;
+        IntPtr togglePtr, quitPtr, slot1Ptr, slot2Ptr, cancelPtr, configPtr, autoOffPtr, wakePtr;
         unsafe
         {
             togglePtr  = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnTogglePressed;
@@ -219,6 +323,7 @@ internal static class Program
             slot1Ptr   = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnSlot1Pressed;
             slot2Ptr   = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnSlot2Pressed;
             cancelPtr  = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnCancelSchedulePressed;
+            configPtr  = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnConfigurePressed;
             autoOffPtr = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnAutoOffFired;
             wakePtr    = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&OnWakeOrUnlock;
         }
@@ -229,6 +334,7 @@ internal static class Program
         class_addMethod(actionClass, Sel("slot1:"),          slot1Ptr,   "v@:@");
         class_addMethod(actionClass, Sel("slot2:"),          slot2Ptr,   "v@:@");
         class_addMethod(actionClass, Sel("cancelSchedule:"), cancelPtr,  "v@:@");
+        class_addMethod(actionClass, Sel("configure:"),      configPtr,  "v@:@");
         class_addMethod(actionClass, Sel("autoOff:"),        autoOffPtr, "v@:@");
         class_addMethod(actionClass, Sel("wakeOrUnlock:"),   wakePtr,    "v@:@");
         objc_registerClassPair(actionClass);
@@ -267,6 +373,12 @@ internal static class Program
         Msg(_slot2Item, Sel("setAction:"), Sel("slot2:"));
         Msg(_slot2Item, Sel("setTarget:"), actionTarget);
         Msg(menu, Sel("addItem:"), _slot2Item);
+
+        var configureItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
+        Msg(configureItem, Sel("setTitle:"), NSString("Configure auto-off..."));
+        Msg(configureItem, Sel("setAction:"), Sel("configure:"));
+        Msg(configureItem, Sel("setTarget:"), actionTarget);
+        Msg(menu, Sel("addItem:"), configureItem);
 
         Msg(menu, Sel("addItem:"), Msg(Cls("NSMenuItem"), Sel("separatorItem")));
 

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -15,6 +15,7 @@ internal static class Program
     private const string LibSystem = "/usr/lib/libSystem.dylib";
     private const string AppKitPath = "/System/Library/Frameworks/AppKit.framework/AppKit";
     private const string AppServicesPath = "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices";
+    private const string IOKitPath = "/System/Library/Frameworks/IOKit.framework/IOKit";
 
     [DllImport(LibSystem)] private static extern IntPtr dlopen(string path, int mode);
     private const int RTLD_NOW = 2;
@@ -92,6 +93,8 @@ internal static class Program
             throw new InvalidOperationException($"failed to dlopen {AppKitPath}");
         if (dlopen(AppServicesPath, RTLD_NOW) == IntPtr.Zero)
             throw new InvalidOperationException($"failed to dlopen {AppServicesPath}");
+        if (dlopen(IOKitPath, RTLD_NOW) == IntPtr.Zero)
+            throw new InvalidOperationException($"failed to dlopen {IOKitPath}");
 
         // Trigger the macOS Accessibility permission prompt at startup
         // instead of waiting for the first CGEventPost (which silently fails

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -1,4 +1,7 @@
+using System.Globalization;
 using System.Runtime.InteropServices;
+using NeverAway.Core;
+using static NeverAway.Core.AutoOffSchedule;
 
 namespace NeverAway.Mac;
 
@@ -30,9 +33,13 @@ internal static class Program
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr Msg(IntPtr o, IntPtr s);
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr Msg(IntPtr o, IntPtr s, IntPtr a);
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr Msg(IntPtr o, IntPtr s, IntPtr a, IntPtr b);
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr Msg(IntPtr o, IntPtr s, IntPtr a, IntPtr b, IntPtr c);
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr Msg(IntPtr o, IntPtr s, IntPtr a, IntPtr b, IntPtr c, IntPtr d);
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr MsgD(IntPtr o, IntPtr s, double a);
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern void MsgVL(IntPtr o, IntPtr s, long a);
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr MsgB(IntPtr o, IntPtr s, byte b);
+    // performSelectorOnMainThread:withObject:waitUntilDone: -- last arg is BOOL (byte).
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern void MsgPerformOnMain(IntPtr o, IntPtr s, IntPtr a, IntPtr b, byte c);
 
     // Accessibility check + auto-prompt. Documented in <ApplicationServices/AXUIElement.h>.
     // Pass a CFDictionary with kAXTrustedCheckOptionPrompt=YES to fire the system prompt
@@ -60,7 +67,13 @@ internal static class Program
     private static volatile bool _isActive = true;
     private static IntPtr _toggleItem;
     private static IntPtr _statusButton;
+    private static IntPtr _statusItem;       // for setToolTip:
+    private static IntPtr _slot1Item;
+    private static IntPtr _slot2Item;
+    private static IntPtr _cancelScheduleItem;
+    private static IntPtr _actionTarget;
     private static MacInputSimulator? _sim;
+    private static readonly AutoOffSchedule _schedule = new();
 
     // Match the Windows tray's deliberate icon choice:
     //   active   = SystemIcons.Error (red alert)        -> "no entry" ⛔
@@ -68,19 +81,78 @@ internal static class Program
     private const string IconActive = "⛔";   // ⛔
     private const string IconInactive = "🛡️"; // 🛡 with VS-16
 
-    [UnmanagedCallersOnly]
-    private static void OnTogglePressed(IntPtr self, IntPtr cmd)
+    // NSControlStateValueOn = 1, NSControlStateValueMixed = -1, NSControlStateValueOff = 0
+    private const long NSControlStateOn    = 1;
+    private const long NSControlStateMixed = -1;
+    private const long NSControlStateOff   = 0;
+
+    // Regular method -- both menu-click and tap-loop auto-off route here.
+    // Mirror of Windows TrayApp.Toggle(isAuto).
+    private static void Toggle(bool isAuto)
     {
         _isActive = !_isActive;
+        if (!_isActive)
+        {
+            _schedule.Cause = isAuto ? OffCause.Auto : OffCause.Manual;
+            // Manual-off clears any pending schedule (the off it was going to
+            // trigger already happened). Auto-off keeps the schedule alive so
+            // Daily mode can rearm in OnFired.
+            if (!isAuto) _schedule.Cancel();
+            _sim?.ReleaseAllAssertions();
+        }
+        else
+        {
+            _schedule.Cause = OffCause.None;
+        }
         if (_toggleItem != IntPtr.Zero)
             Msg(_toggleItem, Sel("setTitle:"), NSString(_isActive ? "Pause" : "Resume"));
         if (_statusButton != IntPtr.Zero)
             Msg(_statusButton, Sel("setTitle:"), NSString(_isActive ? IconActive : IconInactive));
-        // On Pause, release IOPM assertions so the OS resumes normal idle
-        // behavior (display sleep, screen lock can fire). On Resume, the
-        // next Tap() re-creates them via EnsurePersistentAssertions().
-        if (!_isActive)
-            _sim?.ReleaseAllAssertions();
+        RefreshScheduleMenu();
+    }
+
+    [UnmanagedCallersOnly]
+    private static void OnTogglePressed(IntPtr self, IntPtr cmd) => Toggle(isAuto: false);
+
+    // Called via performSelectorOnMainThread: from the tap loop when the
+    // schedule fires. Marshals the auto-off onto the main thread so the
+    // menu / status-bar updates happen safely.
+    [UnmanagedCallersOnly]
+    private static void OnAutoOffFired(IntPtr self, IntPtr cmd)
+    {
+        if (!_isActive) return;
+        _schedule.OnFired(DateTime.Now);
+        Toggle(isAuto: true);
+    }
+
+    [UnmanagedCallersOnly]
+    private static void OnSlot1Pressed(IntPtr self, IntPtr cmd)
+    {
+        _schedule.Cycle(_schedule.Slot1, DateTime.Now);
+        RefreshScheduleMenu();
+    }
+
+    [UnmanagedCallersOnly]
+    private static void OnSlot2Pressed(IntPtr self, IntPtr cmd)
+    {
+        _schedule.Cycle(_schedule.Slot2, DateTime.Now);
+        RefreshScheduleMenu();
+    }
+
+    [UnmanagedCallersOnly]
+    private static void OnCancelSchedulePressed(IntPtr self, IntPtr cmd)
+    {
+        _schedule.Cancel();
+        RefreshScheduleMenu();
+    }
+
+    // NSWorkspace session-unlock + power-resume both route here. Re-arm
+    // NeverAway iff the last off was auto (not manual).
+    [UnmanagedCallersOnly]
+    private static void OnWakeOrUnlock(IntPtr self, IntPtr cmd, IntPtr notification)
+    {
+        if (_isActive || _schedule.Cause != OffCause.Auto) return;
+        Toggle(isAuto: false);
     }
 
     [UnmanagedCallersOnly]
@@ -129,17 +201,29 @@ internal static class Program
         // The Objective-C runtime needs a real class with selectors --
         // can't dispatch [target action:] to a raw function pointer.
         var actionClass = objc_allocateClassPair(Cls("NSObject"), "NeverAwayActionTarget", 0);
-        IntPtr togglePtr, quitPtr;
+        IntPtr togglePtr, quitPtr, slot1Ptr, slot2Ptr, cancelPtr, autoOffPtr, wakePtr;
         unsafe
         {
-            togglePtr = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnTogglePressed;
-            quitPtr = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnQuitPressed;
+            togglePtr  = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnTogglePressed;
+            quitPtr    = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnQuitPressed;
+            slot1Ptr   = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnSlot1Pressed;
+            slot2Ptr   = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnSlot2Pressed;
+            cancelPtr  = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnCancelSchedulePressed;
+            autoOffPtr = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnAutoOffFired;
+            wakePtr    = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&OnWakeOrUnlock;
         }
         // type encoding "v@:@" = void return, self (id), cmd (SEL), one id arg
-        class_addMethod(actionClass, Sel("toggle:"), togglePtr, "v@:@");
-        class_addMethod(actionClass, Sel("quit:"), quitPtr, "v@:@");
+        // wake selector takes (id)notification, hence the same v@:@ signature.
+        class_addMethod(actionClass, Sel("toggle:"),         togglePtr,  "v@:@");
+        class_addMethod(actionClass, Sel("quit:"),           quitPtr,    "v@:@");
+        class_addMethod(actionClass, Sel("slot1:"),          slot1Ptr,   "v@:@");
+        class_addMethod(actionClass, Sel("slot2:"),          slot2Ptr,   "v@:@");
+        class_addMethod(actionClass, Sel("cancelSchedule:"), cancelPtr,  "v@:@");
+        class_addMethod(actionClass, Sel("autoOff:"),        autoOffPtr, "v@:@");
+        class_addMethod(actionClass, Sel("wakeOrUnlock:"),   wakePtr,    "v@:@");
         objc_registerClassPair(actionClass);
-        var actionTarget = Msg(Msg(actionClass, Sel("alloc")), Sel("init"));
+        _actionTarget = Msg(Msg(actionClass, Sel("alloc")), Sel("init"));
+        var actionTarget = _actionTarget;
 
         // NSApplication.sharedApplication, set as Accessory (menu-bar only)
         var app = Msg(Cls("NSApplication"), Sel("sharedApplication"));
@@ -147,12 +231,12 @@ internal static class Program
 
         // Status item with variable length, icon as title (see IconActive/IconInactive)
         var statusBar = Msg(Cls("NSStatusBar"), Sel("systemStatusBar"));
-        var statusItem = MsgD(statusBar, Sel("statusItemWithLength:"), -1.0); // NSVariableStatusItemLength
-        _statusButton = Msg(statusItem, Sel("button"));
+        _statusItem = MsgD(statusBar, Sel("statusItemWithLength:"), -1.0); // NSVariableStatusItemLength
+        _statusButton = Msg(_statusItem, Sel("button"));
         Msg(_statusButton, Sel("setTitle:"), NSString(IconActive));
         Msg(_statusButton, Sel("setToolTip:"), NSString("NeverAway"));
 
-        // Menu: Pause / -- / Quit
+        // Menu: Pause / -- / Slot1 / Slot2 / -- / Cancel scheduled auto-off / -- / Quit
         var menu = Msg(Msg(Cls("NSMenu"), Sel("alloc")), Sel("init"));
 
         var pauseItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
@@ -164,13 +248,49 @@ internal static class Program
 
         Msg(menu, Sel("addItem:"), Msg(Cls("NSMenuItem"), Sel("separatorItem")));
 
+        _slot1Item = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
+        Msg(_slot1Item, Sel("setAction:"), Sel("slot1:"));
+        Msg(_slot1Item, Sel("setTarget:"), actionTarget);
+        Msg(menu, Sel("addItem:"), _slot1Item);
+
+        _slot2Item = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
+        Msg(_slot2Item, Sel("setAction:"), Sel("slot2:"));
+        Msg(_slot2Item, Sel("setTarget:"), actionTarget);
+        Msg(menu, Sel("addItem:"), _slot2Item);
+
+        Msg(menu, Sel("addItem:"), Msg(Cls("NSMenuItem"), Sel("separatorItem")));
+
+        _cancelScheduleItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
+        Msg(_cancelScheduleItem, Sel("setTitle:"), NSString("Cancel scheduled auto-off"));
+        Msg(_cancelScheduleItem, Sel("setAction:"), Sel("cancelSchedule:"));
+        Msg(_cancelScheduleItem, Sel("setTarget:"), actionTarget);
+        Msg(_cancelScheduleItem, Sel("setHidden:"), (IntPtr)1);
+        Msg(menu, Sel("addItem:"), _cancelScheduleItem);
+
+        Msg(menu, Sel("addItem:"), Msg(Cls("NSMenuItem"), Sel("separatorItem")));
+
         var quitItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
         Msg(quitItem, Sel("setTitle:"), NSString("Quit NeverAway"));
         Msg(quitItem, Sel("setAction:"), Sel("quit:"));
         Msg(quitItem, Sel("setTarget:"), actionTarget);
         Msg(menu, Sel("addItem:"), quitItem);
 
-        Msg(statusItem, Sel("setMenu:"), menu);
+        Msg(_statusItem, Sel("setMenu:"), menu);
+
+        // Subscribe to NSWorkspace notifications for auto-on re-arm:
+        //   NSWorkspaceSessionDidBecomeActiveNotification -- session unlock
+        //   NSWorkspaceDidWakeNotification -- system wake from sleep
+        var workspace = Msg(Cls("NSWorkspace"), Sel("sharedWorkspace"));
+        var wsCenter = Msg(workspace, Sel("notificationCenter"));
+        var wakeSel = Sel("wakeOrUnlock:");
+        Msg(wsCenter, Sel("addObserver:selector:name:object:"),
+            actionTarget, wakeSel,
+            NSString("NSWorkspaceSessionDidBecomeActiveNotification"), IntPtr.Zero);
+        Msg(wsCenter, Sel("addObserver:selector:name:object:"),
+            actionTarget, wakeSel,
+            NSString("NSWorkspaceDidWakeNotification"), IntPtr.Zero);
+
+        RefreshScheduleMenu();
 
         // Tap loop on threadpool. CGEvent posting is thread-safe.
         // Stored in static _sim so the toggle handler can call
@@ -185,6 +305,16 @@ internal static class Program
                 {
                     try { sim.Tap(); }
                     catch { /* one bad tap shouldn't kill the loop */ }
+
+                    // Schedule check: if the auto-off slot has fired, marshal
+                    // the toggle onto the main thread (menu / status-bar
+                    // updates aren't thread-safe).
+                    if (_schedule.ShouldFire(DateTime.Now) && _actionTarget != IntPtr.Zero)
+                    {
+                        MsgPerformOnMain(_actionTarget,
+                            Sel("performSelectorOnMainThread:withObject:waitUntilDone:"),
+                            Sel("autoOff:"), IntPtr.Zero, 0);
+                    }
                 }
                 await Task.Delay(TimeSpan.FromSeconds(10));
             }
@@ -193,4 +323,69 @@ internal static class Program
         // Run the main runloop -- blocks until terminate:
         Msg(app, Sel("run"));
     }
+
+    // ----- Schedule menu helpers (mirror of Windows TrayApp.RefreshScheduleMenu) -----
+
+    private static void RefreshScheduleMenu()
+    {
+        if (_slot1Item != IntPtr.Zero)
+        {
+            Msg(_slot1Item, Sel("setTitle:"), NSString(LabelFor(_schedule.Slot1)));
+            MsgVL(_slot1Item, Sel("setState:"), StateValueFor(_schedule.Slot1));
+        }
+        if (_slot2Item != IntPtr.Zero)
+        {
+            Msg(_slot2Item, Sel("setTitle:"), NSString(LabelFor(_schedule.Slot2)));
+            MsgVL(_slot2Item, Sel("setState:"), StateValueFor(_schedule.Slot2));
+        }
+        if (_cancelScheduleItem != IntPtr.Zero)
+        {
+            byte hidden = _schedule.ActiveSlot is null ? (byte)1 : (byte)0;
+            MsgB(_cancelScheduleItem, Sel("setHidden:"), hidden);
+        }
+        UpdateTooltip();
+    }
+
+    private static void UpdateTooltip()
+    {
+        if (_statusButton == IntPtr.Zero) return;
+        string tip;
+        if (!_isActive)
+            tip = "NeverAway is off.";
+        else if (_schedule.FireAt is { } t)
+            tip = $"NeverAway is on. Auto-off at {t.ToString("h:mm tt", CultureInfo.InvariantCulture)}.";
+        else
+            tip = "NeverAway is on.";
+        Msg(_statusButton, Sel("setToolTip:"), NSString(tip));
+    }
+
+    private static string LabelFor(Slot slot)
+    {
+        var baseLabel = slot.Kind == SlotKind.Duration
+            ? FormatDuration(slot.Value)
+            : $"Auto-off at {DateTime.Today.Add(slot.Value).ToString("h:mm tt", CultureInfo.InvariantCulture)}";
+
+        return slot.Mode switch
+        {
+            SlotMode.Once  => $"{baseLabel} (once)",
+            SlotMode.Daily => $"Auto-off daily at {DateTime.Today.Add(slot.Value).ToString("h:mm tt", CultureInfo.InvariantCulture)}",
+            _              => baseLabel,
+        };
+    }
+
+    private static string FormatDuration(TimeSpan ts)
+    {
+        var hours = (int)ts.TotalHours;
+        var minutes = ts.Minutes;
+        if (hours > 0 && minutes > 0) return $"Auto-off in {hours}h {minutes}m";
+        if (hours > 0)                return $"Auto-off in {hours} hour{(hours == 1 ? "" : "s")}";
+        return $"Auto-off in {minutes} minute{(minutes == 1 ? "" : "s")}";
+    }
+
+    private static long StateValueFor(Slot slot) => slot.Mode switch
+    {
+        SlotMode.Once  => NSControlStateOn,
+        SlotMode.Daily => NSControlStateMixed, // visually bolder than a check (mirrors Windows Indeterminate)
+        _              => NSControlStateOff,
+    };
 }

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -287,18 +287,30 @@ internal static class Program
 
         Msg(_statusItem, Sel("setMenu:"), menu);
 
-        // Subscribe to NSWorkspace notifications for auto-on re-arm:
-        //   NSWorkspaceSessionDidBecomeActiveNotification -- session unlock
-        //   NSWorkspaceDidWakeNotification -- system wake from sleep
+        // Subscribe to two notification streams for auto-on re-arm:
+        //
+        //   1. NSWorkspaceDidWakeNotification on [NSWorkspace sharedWorkspace]
+        //      notificationCenter -- fires when the system wakes from sleep.
+        //
+        //   2. "com.apple.screenIsUnlocked" on NSDistributedNotificationCenter --
+        //      fires when the screen unlocks. NOT exposed via NSWorkspace
+        //      (the Workspace SessionDidBecomeActive notification is for
+        //      fast-user-switching, NOT screen lock/unlock as one might guess
+        //      from the name). The Mac equivalent of Windows'
+        //      SessionSwitchReason.SessionUnlock comes through the distributed
+        //      notification center.
+        var wakeSel = Sel("wakeOrUnlock:");
+
         var workspace = Msg(Cls("NSWorkspace"), Sel("sharedWorkspace"));
         var wsCenter = Msg(workspace, Sel("notificationCenter"));
-        var wakeSel = Sel("wakeOrUnlock:");
-        Msg(wsCenter, Sel("addObserver:selector:name:object:"),
-            actionTarget, wakeSel,
-            NSString("NSWorkspaceSessionDidBecomeActiveNotification"), IntPtr.Zero);
         Msg(wsCenter, Sel("addObserver:selector:name:object:"),
             actionTarget, wakeSel,
             NSString("NSWorkspaceDidWakeNotification"), IntPtr.Zero);
+
+        var distCenter = Msg(Cls("NSDistributedNotificationCenter"), Sel("defaultCenter"));
+        Msg(distCenter, Sel("addObserver:selector:name:object:"),
+            actionTarget, wakeSel,
+            NSString("com.apple.screenIsUnlocked"), IntPtr.Zero);
 
         RefreshScheduleMenu();
 

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -96,17 +96,28 @@ internal static class Program
         if (dlopen(IOKitPath, RTLD_NOW) == IntPtr.Zero)
             throw new InvalidOperationException($"failed to dlopen {IOKitPath}");
 
-        // Trigger the macOS Accessibility permission prompt at startup
-        // instead of waiting for the first CGEventPost (which silently fails
-        // when not granted -- no auto-prompt, unlike osascript). Builds
-        // [NSDictionary dictionaryWithObject:@YES forKey:@"AXTrustedCheckOptionPrompt"]
-        // and passes it to AXIsProcessTrustedWithOptions.
+        // Trigger the macOS Accessibility permission prompt at startup --
+        // but only if we're actually untrusted. The naive single-call
+        // AXIsProcessTrustedWithOptions(prompt:YES) approach fires the
+        // prompt on every launch for ad-hoc-signed bundles even when
+        // System Settings shows the toggle as already on (Apple API
+        // quirk or trust-DB race on first launch). Two-step: check
+        // without prompting first; only prompt if the silent check
+        // returns false. Avoids the every-launch prompt UX while still
+        // surfacing the dialog on truly-first-grant.
         var promptKey = NSString("AXTrustedCheckOptionPrompt");
-        var trueVal = MsgB(Cls("NSNumber"), Sel("numberWithBool:"), 1);
-        var options = Msg(Cls("NSDictionary"), Sel("dictionaryWithObject:forKey:"), trueVal, promptKey);
-        AXIsProcessTrustedWithOptions(options);
-        // Return value intentionally ignored. If user grants, future taps work.
-        // If user dismisses, taps silently fail until they re-launch and grant.
+        var falseVal = MsgB(Cls("NSNumber"), Sel("numberWithBool:"), 0);
+        var silentCheckOptions = Msg(Cls("NSDictionary"), Sel("dictionaryWithObject:forKey:"), falseVal, promptKey);
+        bool alreadyTrusted = AXIsProcessTrustedWithOptions(silentCheckOptions);
+        if (!alreadyTrusted)
+        {
+            var trueVal = MsgB(Cls("NSNumber"), Sel("numberWithBool:"), 1);
+            var promptOptions = Msg(Cls("NSDictionary"), Sel("dictionaryWithObject:forKey:"), trueVal, promptKey);
+            AXIsProcessTrustedWithOptions(promptOptions);
+            // Return value intentionally ignored. If user grants, future taps
+            // work. If user dismisses, taps silently fail until they re-launch
+            // and grant.
+        }
 
         // Custom NSObject subclass to host the menu-action callbacks.
         // The Objective-C runtime needs a real class with selectors --

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -73,7 +73,17 @@ internal static class Program
     private static IntPtr _cancelScheduleItem;
     private static IntPtr _actionTarget;
     private static MacInputSimulator? _sim;
-    private static readonly AutoOffSchedule _schedule = new();
+    private static readonly AutoOffSchedule _schedule = new()
+    {
+        // Test-cycle defaults: Core's defaults (2h / 6:00 PM) require
+        // long waits to validate. Mac is mid-development; until the
+        // Configure dialog lands in phase 2, override to short values
+        // so click-cycle + schedule-firing + auto-on can be tested in
+        // ~minutes. Restore Core defaults (or wire Configure dialog)
+        // before v3.0.2 ships.
+        Slot1 = { Value = TimeSpan.FromMinutes(1) }, // Duration 1 min
+        Slot2 = { Value = new TimeSpan(23, 59, 0) }, // Absolute 11:59 PM
+    };
 
     // Match the Windows tray's deliberate icon choice:
     //   active   = SystemIcons.Error (red alert)        -> "no entry" ⛔

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -87,17 +87,7 @@ internal static class Program
     private static IntPtr _cancelScheduleItem;
     private static IntPtr _actionTarget;
     private static MacInputSimulator? _sim;
-    private static readonly AutoOffSchedule _schedule = new()
-    {
-        // Test-cycle defaults: Core's defaults (2h / 6:00 PM) require
-        // long waits to validate. Mac is mid-development; until the
-        // Configure dialog lands in phase 2, override to short values
-        // so click-cycle + schedule-firing + auto-on can be tested in
-        // ~minutes. Restore Core defaults (or wire Configure dialog)
-        // before v3.0.2 ships.
-        Slot1 = { Value = TimeSpan.FromMinutes(1) }, // Duration 1 min
-        Slot2 = { Value = new TimeSpan(23, 59, 0) }, // Absolute 11:59 PM
-    };
+    private static readonly AutoOffSchedule _schedule = new();
 
     // Match the Windows tray's deliberate icon choice:
     //   active   = SystemIcons.Error (red alert)        -> "no entry" ⛔


### PR DESCRIPTION
closes #6, scope expanded from "lock fix v3.0.1" → "feature parity v3.1.0".

## summary

v3.0.0 mac prevented display darkening but **not screen lock**. v3.0.0 mac also lagged behind Windows on the auto-off / scheduler / Configure dialog / auto-on lifecycle. v3.1.0 fixes both: kitchen-sink lock prevention + feature parity with the Windows tray.

## what changed

### lock prevention (the original bug)

`MacInputSimulator` layers four mechanisms to prevent the lock:

1. `IOPMAssertionCreateWithName(PreventUserIdleDisplaySleep)` — persistent
2. `IOPMAssertionCreateWithName(PreventUserIdleSystemSleep)` — persistent
3. `IOPMAssertionDeclareUserActivity(kIOPMUserActiveLocal)` — refreshed each Tap()
4. zero-pixel `CGEventCreateMouseEvent(kCGEventMouseMoved)` — each Tap(), keeps Teams/Slack away suppression working AND resets the display-sleep idle counter

Pause releases all 3 IOPM assertions cleanly so the machine can lock if user wants; Resume re-creates them.

### Windows feature parity

Mac menubar app now matches the Windows tray feature set:

- two-slot auto-off scheduler (`AutoOffSchedule` shared from `NeverAway.Core`)
- click-cycling: Slot 1 (Duration) cycles Off ↔ Once; Slot 2 (Absolute) cycles Off → Once → Daily → Off
- "Configure auto-off..." dialog (NSAlert with two text fields: Slot 1 minutes, Slot 2 HH:MM)
- "Cancel scheduled auto-off" menu item (auto-hides when no slot armed)
- defaults match Windows: 2h Duration / 6:00 PM Absolute
- auto-on re-arm on real screen-unlock (`com.apple.screenIsUnlocked` distributed notification) and system wake (`NSWorkspaceDidWakeNotification`)
- only re-arms if last off was auto (Cause==Auto), matching Windows behavior

### supporting work

- `docs/macos-lock-investigation.md` — cold-read investigation log: what we tried, what each macOS idle counter does, dead ends, the kitchen-sink rationale
- `docs/test-plan.md` — operational catalogue of test scripts + user-intervention notes
- `scripts/test-lock-prevention.sh` — kitchen-sink prevents the lock during natural idle windows
- `scripts/test-isolation.sh` — which layer of kitchen-sink is doing the work
- `scripts/test-auto-off.sh` — arms slot, watches assertions drop
- `scripts/test-auto-on.sh` — synthetic unlock → watches re-arm (works only for entitled .app, not CLI swift — see test-plan.md caveat)
- `scripts/test-full-gate.sh` — runs gates 1-6 in sequence
- `scripts/test-comprehensive-gates.sh` — 3-phase test (NeverAway ON / OFF / ON) with all 5 macOS idle timers set to distinct short values

## empirical validation

| test | result |
|---|---|
| 2h15min real-world idle, kitchen-sink active | screen did not lock |
| control with NeverAway killed | lock fired at expected time |
| slot 1 click-cycle + arm + auto-off | menu state + IOPM release correct, fires at scheduled time |
| auto-on on real lock+unlock | NeverAway re-armed within seconds |
| Configure dialog Save commits new slot values | empirical (Roy tested Duration + Absolute paths) |
| comprehensive-gates: phase A (on) | display-off=0 |
| comprehensive-gates: phase B (off) | display-off=1 (gate fired at predicted time) |
| comprehensive-gates: phase C (on) | display-off=0, re-arm works |

## not in this PR

- README.md mac-row tech-table accuracy (`F19 (key code 80)` → kitchen-sink). Roy's domain.
- virtual-HID-device approach (`IOHIDUserDevice`) — would route synthetic events through the real-hardware path; deferred since not needed (kitchen-sink works).
- Configure dialog Kind switching (Duration ↔ Absolute per slot). Windows has it via radio buttons; mac dialog has fixed kinds (Slot 1 = Duration, Slot 2 = Absolute). Could land in v3.2.

ready for review + merge → tag v3.1.0 → release.