### PR TITLE
fix(mac): add Entitlements.plist for .NET under hardened runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,12 @@ jobs:
               exit 1
             fi
             echo "signing with identity: $IDENTITY"
+            # --entitlements: required for the .NET runtime to function under
+            # hardened runtime. Without allow-jit + allow-unsigned-executable-
+            # memory + disable-library-validation, CoreCLR can't initialize
+            # and the app fails on launch with HRESULT 0x80070008.
             codesign --force --deep --options runtime --timestamp \
+              --entitlements src/NeverAway.Mac/Entitlements.plist \
               --sign "$IDENTITY" "$APP"
             echo "::endgroup::"
           else

--- a/src/NeverAway.Mac/Entitlements.plist
+++ b/src/NeverAway.Mac/Entitlements.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Entitlements required for a .NET (CoreCLR) app running under the
+        hardened runtime. Without these, CoreCLR fails to initialize:
+            "Failed to create CoreCLR, HRESULT: 0x80070008"
+        because the JIT can't allocate executable memory pages.
+
+        com.apple.security.cs.allow-jit
+            Permits the runtime to mark pages as executable for JIT-compiled
+            code (CoreCLR's primary code-execution mechanism).
+
+        com.apple.security.cs.allow-unsigned-executable-memory
+            Permits unsigned executable memory pages. Required because the
+            JIT writes new code at runtime that wasn't part of the original
+            signed binary.
+
+        com.apple.security.cs.disable-library-validation
+            Permits loading of dynamic libraries that aren't signed by the
+            same Team ID. .NET bundles + loads its own native libs (e.g.
+            System.Native.dylib) at runtime; without this, they'd be
+            rejected by strict library validation under hardened runtime.
+
+        These are the standard set for .NET single-file apps on macOS with
+        Developer ID signing + notarization. Apple's notary service accepts
+        them.
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
closes #11

v3.1.1 mac binary fails to launch with \`Failed to create CoreCLR, HRESULT: 0x80070008\`. Root cause: hardened runtime (added in PR #10 for notarization) blocks JIT, which CoreCLR requires. Fix: add \`src/NeverAway.Mac/Entitlements.plist\` granting the three .NET-needed entitlements, pass to codesign via \`--entitlements\`.

Verified locally: re-signed the v3.1.1 bundle with the entitlements (ad-hoc), launched, CoreCLR initialized, process stayed alive.

After merge: tag v3.1.2, ship, mark v3.1.1 mac asset as broken.