### PR TITLE
feat(mac): Sparkle auto-updates + fix repeated Accessibility prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,20 @@ name: CI
 on:
   push:
     branches: [master]
+    tags: ['v*']
   pull_request:
+
+# Sparkle version embedded in the mac bundle + used by the release job's
+# generate_appcast. Keep the two jobs on the same version.
+env:
+  SPARKLE_VERSION: 2.9.4
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
       - name: dotnet build (Core)
@@ -39,7 +45,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
@@ -64,6 +70,18 @@ jobs:
           cp src/NeverAway.Mac/Info.plist $APP/Contents/Info.plist
           cp publish/mac-binary/neveraway $APP/Contents/MacOS/neveraway
           chmod +x $APP/Contents/MacOS/neveraway
+
+          # Embed Sparkle.framework for auto-updates (Program.cs dlopens
+          # Contents/Frameworks/Sparkle.framework/Sparkle at launch).
+          curl -sL -o "$RUNNER_TEMP/sparkle.tar.xz" \
+            "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz"
+          mkdir -p "$RUNNER_TEMP/sparkle"
+          tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP/sparkle"
+          mkdir -p $APP/Contents/Frameworks
+          cp -R "$RUNNER_TEMP/sparkle/Sparkle.framework" $APP/Contents/Frameworks/
+          # Sparkle's XPC services are only needed by sandboxed hosts;
+          # NeverAway isn't sandboxed. Removing them simplifies signing.
+          rm -rf $APP/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices
 
           if [ -n "$CERT_P12_B64" ]; then
             echo "::group::Developer ID signing path"
@@ -92,11 +110,19 @@ jobs:
               exit 1
             fi
             echo "signing with identity: $IDENTITY"
+            # Sign nested Sparkle pieces first (inside-out). No --deep on
+            # the final app sign: --deep would re-sign nested code with the
+            # app's entitlements, and Sparkle's helpers must NOT carry the
+            # .NET JIT entitlements.
+            FW=$APP/Contents/Frameworks/Sparkle.framework
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$FW/Versions/B/Autoupdate"
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$FW/Versions/B/Updater.app"
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$FW"
             # --entitlements: required for the .NET runtime to function under
             # hardened runtime. Without allow-jit + allow-unsigned-executable-
             # memory + disable-library-validation, CoreCLR can't initialize
             # and the app fails on launch with HRESULT 0x80070008.
-            codesign --force --deep --options runtime --timestamp \
+            codesign --force --options runtime --timestamp \
               --entitlements src/NeverAway.Mac/Entitlements.plist \
               --sign "$IDENTITY" "$APP"
             echo "::endgroup::"
@@ -142,16 +168,30 @@ jobs:
 
           rm "$ZIP"
 
+      # ditto preserves executable bits, symlinks, and the stapled ticket --
+      # actions/upload-artifact's own zipping strips the exec bit, which
+      # breaks a downloaded .app. This zip is also what ships in releases
+      # and what generate_appcast signs for Sparkle.
+      - name: ditto-zip app bundle
+        run: |
+          VER=$(defaults read "$PWD/publish/mac-app/NeverAway.app/Contents/Info.plist" CFBundleShortVersionString)
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent publish/mac-app/NeverAway.app "publish/NeverAway-$VER.zip"
+
       - uses: actions/upload-artifact@v7
         with:
           name: neveraway-mac-app
           path: publish/mac-app/
 
+      - uses: actions/upload-artifact@v7
+        with:
+          name: neveraway-mac-zip
+          path: publish/NeverAway-*.zip
+
   build-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
       - name: dotnet build (Windows tray)
@@ -165,3 +205,57 @@ jobs:
         with:
           name: neveraway-win-x64
           path: publish/win-x64/
+
+  # Tag push (v*) -> GitHub release with the mac zip, windows zip, and a
+  # Sparkle appcast.xml. SUFeedURL in Info.plist points at
+  # releases/latest/download/appcast.xml, so publishing the release is
+  # what makes installed apps see the update. Tag must match the version
+  # in src/NeverAway.Mac/Info.plist (bump it before tagging).
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test, build-mac-app, build-windows]
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: neveraway-mac-zip
+          path: appcast-dir
+      - uses: actions/download-artifact@v8
+        with:
+          name: neveraway-win-x64
+          path: win-x64
+
+      # generate_appcast scans a directory of archives, unpacks each to
+      # read Info.plist versions, and writes EdDSA signatures with the
+      # private key. Only the mac zip may be in that directory.
+      - name: generate Sparkle appcast
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          curl -sL -o "$RUNNER_TEMP/sparkle.tar.xz" \
+            "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz"
+          mkdir -p "$RUNNER_TEMP/sparkle"
+          tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP/sparkle"
+
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$RUNNER_TEMP/ed_key"
+          "$RUNNER_TEMP/sparkle/bin/generate_appcast" \
+            --ed-key-file "$RUNNER_TEMP/ed_key" \
+            --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
+            -o appcast-dir/appcast.xml \
+            appcast-dir
+          rm "$RUNNER_TEMP/ed_key"
+          cat appcast-dir/appcast.xml
+
+      - name: zip windows build
+        run: /usr/bin/ditto -c -k win-x64 "appcast-dir/NeverAway-win-x64.zip"
+
+      - name: create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" appcast-dir/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "NeverAway $GITHUB_REF_NAME" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -37,23 +37,22 @@ Mac v3.1.0 also matches the Windows tray's full feature set: two-slot auto-off s
 
 Download `NeverAway.app` from the latest release (or build it locally — see below), drag it into `/Applications`, double-click. A ⛔ glyph appears in the menu bar. Click for Pause / Quit menu (⛔ flips to 🛡 when paused).
 
-**First-launch gatekeeper bypass.** NeverAway is ad-hoc signed but not signed with an Apple Developer ID, so on first launch macOS blocks it with "could not be verified" or "is damaged". Right-click → Open used to bypass this; it doesn't work on modern macOS (Sonoma / Sequoia / later). Either:
+**Gatekeeper.** Since v3.1.1 releases are signed with an Apple Developer ID and notarized, so macOS accepts the .app on first launch with no "could not be verified" warning. (Builds from CI artifacts on non-release branches may be ad-hoc signed; for those, `xattr -dr com.apple.quarantine /path/to/NeverAway.app` before first launch.)
 
-- **Mouse-only:** try to open → blocked → System Settings → Privacy & Security → scroll to "Security" → "Open Anyway" button next to "NeverAway was blocked..." → confirm → double-click works
-- **Terminal:** `xattr -dr com.apple.quarantine /path/to/NeverAway.app` then double-click
+**Accessibility prompt** fires once on first-ever launch: "NeverAway wants to control your computer using accessibility features." → Open System Settings → flip the toggle next to NeverAway in the Accessibility list → re-launch NeverAway. NeverAway never auto-prompts again after that; if the permission is missing later (fresh machine, signature change), the menu shows **Grant Accessibility Access...** instead. If the Settings toggle shows ON but Teams still marks you Away, the TCC grant is stale — `tccutil reset Accessibility com.royashbrook.neveraway`, re-launch, grant once.
 
-Either is one-time. After first successful launch, macOS remembers the decision.
+**Updates.** The app checks GitHub releases via [Sparkle](https://sparkle-project.org/) and offers to install new versions automatically; **Check for Updates...** in the menu does it on demand.
 
-**Accessibility prompt** on first Tap (~10s after launch): "NeverAway wants to control your computer using accessibility features." → Open System Settings → flip the toggle next to NeverAway in the Accessibility list → re-launch NeverAway.
-
-**Menu** (Mac v3.1.0):
+**Menu** (Mac v3.2.0):
 
 - **Pause / Resume** — toggle keep-awake (click ⛔, flips to 🛡 when paused)
 - **Auto-off in 2 hours** (Slot 1, Duration) — click to cycle Off ↔ Once
 - **Auto-off at 6:00 PM** (Slot 2, Absolute) — click to cycle Off → Once → Daily → Off
 - **Configure auto-off...** — opens a dialog to change slot values (minutes for Slot 1, HH:MM for Slot 2)
 - **Cancel scheduled auto-off** — appears when a slot is armed; cancels it
+- **Grant Accessibility Access...** — only visible when the permission is missing; deep-links to the Settings pane
 - **Start at Login** — launches NeverAway automatically after you log in (macOS 13+)
+- **Check for Updates...** — manual Sparkle update check (only present when running from the .app bundle)
 - **Quit NeverAway**
 
 Auto-on: when the schedule fires (auto-off), unlocking the screen or waking the laptop re-arms NeverAway. Manual-off (clicking Pause) does *not* auto-re-arm — Resume is on you.

--- a/dist/mac-app/README.txt
+++ b/dist/mac-app/README.txt
@@ -31,7 +31,9 @@ How to run
        Auto-off at 6:00 PM         click to arm Slot 2 (Absolute)
        Configure auto-off...       change the slot values
        Cancel scheduled auto-off   visible when a slot is armed
+       Grant Accessibility Access  visible only if permission is missing
        Start at Login              launch NeverAway when you log in
+       Check for Updates...        NeverAway also checks automatically (Sparkle)
        Quit NeverAway
 
 5. The first time NeverAway fires a tap (within ~10s of launch),
@@ -43,6 +45,22 @@ How to run
    Click "Open System Settings", flip the toggle next to
    NeverAway in the Accessibility list, then re-launch
    NeverAway. (One-time setup.)
+
+   NeverAway only auto-prompts once, ever. If permission is
+   missing later (e.g. after a signature change), the menu shows
+   "Grant Accessibility Access..." instead of nagging at launch.
+   If the System Settings toggle is ON but NeverAway still isn't
+   keeping you active, the grant is stale -- reset it once:
+
+       tccutil reset Accessibility com.royashbrook.neveraway
+
+   then re-launch and grant again.
+
+Updates
+-------
+NeverAway checks GitHub releases for updates automatically via
+Sparkle and offers to install them. You can also check manually
+with "Check for Updates..." in the menu.
 
 That's it. Quit via the menu, or it'll keep running until you
 log out / shut down. To start automatically at login, click

--- a/src/NeverAway.Mac/Info.plist
+++ b/src/NeverAway.Mac/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.1.3</string>
+    <string>3.2.0</string>
     <key>CFBundleVersion</key>
-    <string>3.1.3</string>
+    <string>3.2.0</string>
     <key>LSMinimumSystemVersion</key>
     <string>11.0</string>
     <!-- LSUIElement=true: menu-bar-only app, no Dock icon, no main menu bar -->
@@ -29,5 +29,15 @@
     <string>NSApplication</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright (c) 2026 Roy Ashbrook</string>
+    <!-- Sparkle auto-updates. Feed lives on the latest GitHub release;
+         each release uploads an appcast.xml asset (see release job in
+         ci.yml). SUPublicEDKey pairs with the SPARKLE_ED_PRIVATE_KEY
+         repo secret used by generate_appcast to sign update archives. -->
+    <key>SUFeedURL</key>
+    <string>https://github.com/neveraway/neveraway/releases/latest/download/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>u/AVLE144V/KkL4qykgVC5nRd6HxKoQFnnhF8aBcXB0=</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
 </dict>
 </plist>

--- a/src/NeverAway.Mac/NeverAway.Mac.csproj
+++ b/src/NeverAway.Mac/NeverAway.Mac.csproj
@@ -17,7 +17,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>NeverAway.Mac</RootNamespace>
     <AssemblyName>neveraway</AssemblyName>
-    <ApplicationVersion>3.1.3.0</ApplicationVersion>
+    <ApplicationVersion>3.2.0.0</ApplicationVersion>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>

--- a/src/NeverAway.Mac/Program.cs
+++ b/src/NeverAway.Mac/Program.cs
@@ -47,6 +47,8 @@ internal static class Program
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr MsgRect(IntPtr o, IntPtr s, CGRect r);
     // runModal -- returns NSInteger (long).
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern long MsgRetL(IntPtr o, IntPtr s);
+    // initWithStartingUpdater:updaterDelegate:userDriverDelegate: -- BOOL (byte) + two ids.
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")] private static extern IntPtr MsgBPP(IntPtr o, IntPtr s, byte a, IntPtr b, IntPtr c);
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct CGSize { public double Width; public double Height; }
@@ -93,9 +95,16 @@ internal static class Program
     private static IntPtr _slot2Item;
     private static IntPtr _cancelScheduleItem;
     private static IntPtr _startAtLoginItem;
+    private static IntPtr _grantAccessItem;
+    private static IntPtr _updaterController;
     private static IntPtr _actionTarget;
     private static MacInputSimulator? _sim;
     private static readonly AutoOffSchedule _schedule = new();
+
+    // First-ever-launch marker for the Accessibility auto-prompt.
+    private static string AxPromptMarkerPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "Library", "Application Support", "NeverAway", "ax-prompted");
 
     // Match the Windows tray's deliberate icon choice:
     //   active   = SystemIcons.Error (red alert)        -> "no entry" ⛔
@@ -284,6 +293,29 @@ internal static class Program
         Toggle(isAuto: false);
     }
 
+    // Deep-link straight to the Accessibility pane of System Settings.
+    // Used by the "Grant Accessibility Access..." menu item -- the OS-level
+    // prompt (AXIsProcessTrustedWithOptions) only fires reliably once, so
+    // manual re-grant goes through the Settings pane instead.
+    [UnmanagedCallersOnly]
+    private static void OnGrantAccessPressed(IntPtr self, IntPtr cmd)
+    {
+        var url = Msg(Cls("NSURL"), Sel("URLWithString:"),
+            NSString("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"));
+        var workspace = Msg(Cls("NSWorkspace"), Sel("sharedWorkspace"));
+        MsgRetB(workspace, Sel("openURL:"), url);
+    }
+
+    // NSMenu delegate -- refresh dynamic item state right before the menu
+    // shows, so Grant-Accessibility visibility and Start-at-Login state are
+    // current even when nothing else triggered a refresh.
+    [UnmanagedCallersOnly]
+    private static void OnMenuWillOpen(IntPtr self, IntPtr cmd, IntPtr menu)
+    {
+        RefreshGrantAccessMenu();
+        RefreshStartAtLoginMenu();
+    }
+
     [UnmanagedCallersOnly]
     private static void OnQuitPressed(IntPtr self, IntPtr cmd)
     {
@@ -305,30 +337,30 @@ internal static class Program
         dlopen(ServiceManagementPath, RTLD_NOW); // Optional: SMAppService exists on macOS 13+.
 
         // Trigger the macOS Accessibility permission prompt at startup --
-        // but only if we're actually untrusted. The naive single-call
-        // AXIsProcessTrustedWithOptions(prompt:YES) approach fires the
-        // prompt on every launch for ad-hoc-signed bundles even when
-        // System Settings shows the toggle as already on (Apple API
-        // quirk or trust-DB race on first launch). Two-step: check
-        // without prompting first; only prompt if the silent check
-        // returns false. Avoids the every-launch prompt UX while still
-        // surfacing the dialog on truly-first-grant.
-        if (!AXIsProcessTrusted())
+        // but only on the very first launch ever (marker file). The
+        // AXIsProcessTrusted() gate alone is not enough: a stale TCC grant
+        // (recorded against an older build's code signature) leaves the
+        // System Settings toggle ON while the trust check returns false,
+        // which made the prompt fire on every launch forever. Prompt once;
+        // after that, an untrusted state surfaces as a
+        // "Grant Accessibility Access..." menu item instead of a nag dialog.
+        if (!AXIsProcessTrusted() && !File.Exists(AxPromptMarkerPath))
         {
+            Directory.CreateDirectory(Path.GetDirectoryName(AxPromptMarkerPath)!);
+            File.WriteAllText(AxPromptMarkerPath, "");
             var promptKey = NSString("AXTrustedCheckOptionPrompt");
             var trueVal = MsgB(Cls("NSNumber"), Sel("numberWithBool:"), 1);
             var promptOptions = Msg(Cls("NSDictionary"), Sel("dictionaryWithObject:forKey:"), trueVal, promptKey);
             AXIsProcessTrustedWithOptions(promptOptions);
             // Return value intentionally ignored. If user grants, future taps
-            // work. If user dismisses, taps silently fail until they re-launch
-            // and grant.
+            // work. If user dismisses, the menu item remains as the way back in.
         }
 
         // Custom NSObject subclass to host the menu-action callbacks.
         // The Objective-C runtime needs a real class with selectors --
         // can't dispatch [target action:] to a raw function pointer.
         var actionClass = objc_allocateClassPair(Cls("NSObject"), "NeverAwayActionTarget", 0);
-        IntPtr togglePtr, quitPtr, slot1Ptr, slot2Ptr, cancelPtr, startAtLoginPtr, configPtr, autoOffPtr, wakePtr;
+        IntPtr togglePtr, quitPtr, slot1Ptr, slot2Ptr, cancelPtr, startAtLoginPtr, configPtr, autoOffPtr, wakePtr, grantAccessPtr, menuWillOpenPtr;
         unsafe
         {
             togglePtr       = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnTogglePressed;
@@ -340,6 +372,8 @@ internal static class Program
             configPtr       = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnConfigurePressed;
             autoOffPtr      = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnAutoOffFired;
             wakePtr         = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&OnWakeOrUnlock;
+            grantAccessPtr  = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, void>)&OnGrantAccessPressed;
+            menuWillOpenPtr = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&OnMenuWillOpen;
         }
         // type encoding "v@:@" = void return, self (id), cmd (SEL), one id arg
         // wake selector takes (id)notification, hence the same v@:@ signature.
@@ -352,6 +386,8 @@ internal static class Program
         class_addMethod(actionClass, Sel("configure:"),     configPtr,       "v@:@");
         class_addMethod(actionClass, Sel("autoOff:"),       autoOffPtr,      "v@:@");
         class_addMethod(actionClass, Sel("wakeOrUnlock:"),  wakePtr,         "v@:@");
+        class_addMethod(actionClass, Sel("grantAccess:"),   grantAccessPtr,  "v@:@");
+        class_addMethod(actionClass, Sel("menuWillOpen:"),  menuWillOpenPtr, "v@:@");
         objc_registerClassPair(actionClass);
         _actionTarget = Msg(Msg(actionClass, Sel("alloc")), Sel("init"));
         var actionTarget = _actionTarget;
@@ -359,6 +395,26 @@ internal static class Program
         // NSApplication.sharedApplication, set as Accessory (menu-bar only)
         var app = Msg(Cls("NSApplication"), Sel("sharedApplication"));
         MsgVL(app, Sel("setActivationPolicy:"), 1L); // NSApplicationActivationPolicyAccessory
+
+        // Sparkle auto-updates. Only present when running from the
+        // assembled .app bundle (CI embeds Sparkle.framework in
+        // Contents/Frameworks). Bare `dotnet run` / dev binaries skip it.
+        var sparkleBin = Path.Combine(
+            Path.GetDirectoryName(Environment.ProcessPath) ?? "",
+            "..", "Frameworks", "Sparkle.framework", "Sparkle");
+        if (File.Exists(sparkleBin) && dlopen(sparkleBin, RTLD_NOW) != IntPtr.Zero)
+        {
+            var updaterCls = Cls("SPUStandardUpdaterController");
+            if (updaterCls != IntPtr.Zero)
+            {
+                // startingUpdater:YES starts the scheduled-check timer on
+                // the runloop; SUEnableAutomaticChecks in Info.plist skips
+                // Sparkle's "check automatically?" first-run dialog.
+                _updaterController = MsgBPP(Msg(updaterCls, Sel("alloc")),
+                    Sel("initWithStartingUpdater:updaterDelegate:userDriverDelegate:"),
+                    1, IntPtr.Zero, IntPtr.Zero);
+            }
+        }
 
         // Status item with variable length, icon as title (see IconActive/IconInactive)
         var statusBar = Msg(Cls("NSStatusBar"), Sel("systemStatusBar"));
@@ -406,11 +462,28 @@ internal static class Program
 
         Msg(menu, Sel("addItem:"), Msg(Cls("NSMenuItem"), Sel("separatorItem")));
 
+        // Hidden while trusted; surfaces only when Accessibility is missing
+        // (fresh install, or a TCC grant gone stale after a signature change).
+        _grantAccessItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
+        Msg(_grantAccessItem, Sel("setTitle:"), NSString("Grant Accessibility Access..."));
+        Msg(_grantAccessItem, Sel("setAction:"), Sel("grantAccess:"));
+        Msg(_grantAccessItem, Sel("setTarget:"), actionTarget);
+        Msg(menu, Sel("addItem:"), _grantAccessItem);
+
         _startAtLoginItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
         Msg(_startAtLoginItem, Sel("setTitle:"), NSString("Start at Login"));
         Msg(_startAtLoginItem, Sel("setAction:"), Sel("startAtLogin:"));
         Msg(_startAtLoginItem, Sel("setTarget:"), actionTarget);
         Msg(menu, Sel("addItem:"), _startAtLoginItem);
+
+        if (_updaterController != IntPtr.Zero)
+        {
+            var updateItem = Msg(Msg(Cls("NSMenuItem"), Sel("alloc")), Sel("init"));
+            Msg(updateItem, Sel("setTitle:"), NSString("Check for Updates..."));
+            Msg(updateItem, Sel("setAction:"), Sel("checkForUpdates:"));
+            Msg(updateItem, Sel("setTarget:"), _updaterController);
+            Msg(menu, Sel("addItem:"), updateItem);
+        }
 
         Msg(menu, Sel("addItem:"), Msg(Cls("NSMenuItem"), Sel("separatorItem")));
 
@@ -419,6 +492,9 @@ internal static class Program
         Msg(quitItem, Sel("setAction:"), Sel("quit:"));
         Msg(quitItem, Sel("setTarget:"), actionTarget);
         Msg(menu, Sel("addItem:"), quitItem);
+
+        // Delegate so menuWillOpen: refreshes dynamic item state on open.
+        Msg(menu, Sel("setDelegate:"), actionTarget);
 
         Msg(_statusItem, Sel("setMenu:"), menu);
 
@@ -502,6 +578,13 @@ internal static class Program
         }
         UpdateTooltip();
         RefreshStartAtLoginMenu();
+        RefreshGrantAccessMenu();
+    }
+
+    private static void RefreshGrantAccessMenu()
+    {
+        if (_grantAccessItem == IntPtr.Zero) return;
+        MsgB(_grantAccessItem, Sel("setHidden:"), AXIsProcessTrusted() ? (byte)1 : (byte)0);
     }
 
     private static void UpdateTooltip()


### PR DESCRIPTION
Closes #15 (mac half), closes #16.

## Sparkle auto-updates (#15)

- CI embeds Sparkle.framework 2.9.4 into the .app bundle (`Contents/Frameworks`); XPC services removed since the app isn't sandboxed
- `Program.cs` dlopens the framework at launch and drives `SPUStandardUpdaterController` through the existing objc_msgSend P/Invoke layer. No new build deps, and bare `dotnet run` skips it.
- New **Check for Updates...** menu item; automatic checks enabled via `SUEnableAutomaticChecks` (no Sparkle first-run dialog)
- `SUFeedURL` = `releases/latest/download/appcast.xml`; `SUPublicEDKey` pairs with the new `SPARKLE_ED_PRIVATE_KEY` repo secret (already set; private key also in my login keychain)
- New `release` CI job on `v*` tags: ditto-zips the notarized bundle (preserves exec bits + staple), runs `generate_appcast` with the EdDSA key, creates the GitHub release with mac zip + windows zip + appcast.xml
- Nested Sparkle binaries signed individually; `--deep` dropped from the app codesign so Sparkle helpers don't inherit the .NET JIT entitlements

Release flow from now on: bump version in `Info.plist` + csproj, tag `v3.x.y`, push tag. Installed apps pick it up via Sparkle.

## Accessibility prompt fix (#16)

Root cause: stale TCC grant recorded against an older build's signature. System Settings shows the toggle ON but `AXIsProcessTrusted()` returns false, so the existing two-step check prompted on every launch forever.

- Auto-prompt now fires only on first-ever launch (marker file in `~/Library/Application Support/NeverAway`)
- Missing permission afterwards surfaces as a **Grant Accessibility Access...** menu item (deep-link to the Settings pane) instead of a launch nag
- NSMenu delegate (`menuWillOpen:`) refreshes item visibility + Start-at-Login state each time the menu opens

One-time remediation for currently-affected installs: `tccutil reset Accessibility com.royashbrook.neveraway`, re-launch, grant once. The Developer ID designated requirement is stable across versions, so the grant sticks from then on.

## Verified

- `dotnet test` 15/15 pass; mac project builds clean
- Local bundle assembled with Sparkle + ad-hoc signed: launches, Sparkle.framework confirmed loaded in-process, no crash
- `generate_appcast` run locally against the ditto zip: correct `sparkle:version` 3.2.0, EdDSA signature, arm64 requirement

Also: version bump 3.2.0, `setup-dotnet` v5 to v6 (verified latest), README + dist README updates.

Generated with [Claude Code](https://claude.com/claude-code)